### PR TITLE
Disable coming soon upon plugin deactivation

### DIFF
--- a/includes/Deactivation.php
+++ b/includes/Deactivation.php
@@ -47,26 +47,7 @@ class Deactivation {
 	 * @return void
 	 */
 	public function handle() {
-		/*
-		 * The data module is currently handing the 'site_launched' event.
-		 * We are commenting out the code below but keeping it as example for future events.
-		 */
-		// $this->site_launched_event();
 		$this->disable_coming_soon();
-	}
-
-	/**
-	 * Send site launched event.
-	 *
-	 * @return void
-	 */
-	public function site_launched_event() {
-		$coming_soon_service = $this->container->has( 'comingSoon' ) ? $this->container->get( 'comingSoon' ) : null;
-		// Verify that the coming soon page is active.
-		if ( $coming_soon_service && $coming_soon_service->is_enabled() ) {
-			$site_launch_event = new Events\SiteLaunched();
-			$site_launch_event->send();
-		}
 	}
 
 	/**

--- a/includes/Deactivation.php
+++ b/includes/Deactivation.php
@@ -58,6 +58,7 @@ class Deactivation {
 	 */
 	public function site_launched_event() {
 		$coming_soon_service = $this->container->has( 'comingSoon' ) ? $this->container->get( 'comingSoon' ) : null;
+		// Verify that the coming soon page is active.
 		if ( $coming_soon_service && $coming_soon_service->is_enabled() ) {
 			$site_launch_event = new Events\SiteLaunched();
 			$site_launch_event->send();

--- a/includes/Deactivation.php
+++ b/includes/Deactivation.php
@@ -30,9 +30,49 @@ class Deactivation {
 	public function __construct( Container $container ) {
 		$this->container = $container;
 
+		register_deactivation_hook(
+			$container->plugin()->file,
+			array( $this, 'handle' )
+		);
+
 		// Plugin deactivation survey.
 		add_action( 'admin_head-plugins.php', function () {
 			new DeactivationSurvey();
 		} );
+	}
+
+	/**
+	 * Handle deactivation.
+	 *
+	 * @return void
+	 */
+	public function handle() {
+		$this->site_launched_event();
+		$this->disable_coming_soon();
+	}
+
+	/**
+	 * Send site launched event.
+	 *
+	 * @return void
+	 */
+	public function site_launched_event() {
+		$coming_soon_service = $this->container->has( 'comingSoon' ) ? $this->container->get( 'comingSoon' ) : null;
+		if ( $coming_soon_service && $coming_soon_service->is_enabled() ) {
+			$site_launch_event = new Events\SiteLaunched();
+			$site_launch_event->send();
+		}
+	}
+
+	/**
+	 * Disable the coming soon page.
+	 *
+	 * @return void
+	 */
+	public function disable_coming_soon() {
+		$coming_soon_service = $this->container->has( 'comingSoon' ) ? $this->container->get( 'comingSoon' ) : null;
+		if ( $coming_soon_service && $coming_soon_service->is_enabled() ) {
+			$coming_soon_service->disable();
+		}
 	}
 }

--- a/includes/Deactivation.php
+++ b/includes/Deactivation.php
@@ -47,7 +47,11 @@ class Deactivation {
 	 * @return void
 	 */
 	public function handle() {
-		$this->site_launched_event();
+		/*
+		 * The data module is currently handing the 'site_launched' event.
+		 * We are commenting out the code below but keeping it as example for future events.
+		 */
+		// $this->site_launched_event();
 		$this->disable_coming_soon();
 	}
 

--- a/includes/Events/Event.php
+++ b/includes/Events/Event.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Deactivation event.
+ *
+ * @package NewfoldLabs\WP\Module\Deactivation
+ */
+
+namespace NewfoldLabs\WP\Module\Deactivation\Events;
+
+use WP_REST_Request;
+
+/**
+ * Event class.
+ */
+class Event {
+	/**
+	 * Key representing the event action that occurred.
+	 *
+	 * @var string
+	 */
+	public $action;
+
+	/**
+	 * Event category.
+	 *
+	 * @var string
+	 */
+	public $category;
+
+	/**
+	 * Array of extra data related to the event.
+	 *
+	 * @var array
+	 */
+	public $data;
+
+	/**
+	 * Data module endpoint to send the event to.
+	 *
+	 * @var string
+	 */
+	public $endpoint = '/newfold-data/v1/events/';
+
+	/**
+	 * WP_REST_Request instance.
+	 *
+	 * @var WP_REST_Request
+	 */
+	public $request;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $action   Key representing the event action that occurred.
+	 * @param string $category Event category.
+	 * @param array  $data     Array of extra data related to the event.
+	 */
+	public function __construct( $category = 'plugin_deactivation', $data = array() ) {
+		$this->category = $category;
+		$this->data     = $data;
+		$this->request  = new WP_REST_Request( 'POST', $this->endpoint );
+	}
+
+	/**
+	 * Send the event to the data module endpoint.
+	 *
+	 * @return void
+	 */
+	public function sendEvent() {
+		$event = array(
+			'action'   => $this->action,
+			'category' => $this->category,
+			'data'     => $this->data,
+			'queue'    => false,
+		);
+
+		$request = $this->request->set_body_params( $event );
+		rest_do_request( $request );
+	}
+}

--- a/includes/Events/Event.php
+++ b/includes/Events/Event.php
@@ -64,7 +64,7 @@ class Event {
 	/**
 	 * Send the event to the data module endpoint.
 	 *
-	 * @return void
+	 * @return WP_REST_Response REST response
 	 */
 	public function sendEvent() {
 		$event = array(
@@ -73,8 +73,8 @@ class Event {
 			'data'     => $this->data,
 			'queue'    => false,
 		);
-
-		$request = $this->request->set_body_params( $event );
-		rest_do_request( $request );
+		
+		$this->request->set_body( wp_json_encode( $event ) );
+		return rest_do_request( $this->request );
 	}
 }

--- a/includes/Events/SiteLaunched.php
+++ b/includes/Events/SiteLaunched.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Site launched deactivation event.
+ *
+ * @package NewfoldLabs\WP\Module\Deactivation
+ */
+
+namespace NewfoldLabs\WP\Module\Deactivation\Events;
+
+/**
+ * Site launched event class.
+ */
+class SiteLaunched extends Event {
+	/**
+	 * Constructor.
+	 * 
+	 * @return void
+	 */
+	public function send() {
+		$this->action = 'site_launched';
+		$this->data   = array(
+			'ttl' => $this->getInstallTime(),
+		);
+		
+		return $this->sendEvent();
+	}
+
+	/**
+	 * Calculate install time.
+	 * 
+	 * @return int
+	 */
+	private function getInstallTime() {
+		$mm_install_time = get_option( 'mm_install_date', gmdate( 'M d, Y' ) );
+
+		return time() - strtotime( $mm_install_time );
+	}
+}

--- a/includes/Events/SiteLaunched.php
+++ b/includes/Events/SiteLaunched.php
@@ -12,7 +12,7 @@ namespace NewfoldLabs\WP\Module\Deactivation\Events;
  */
 class SiteLaunched extends Event {
 	/**
-	 * Constructor.
+	 * send event.
 	 * 
 	 * @return void
 	 */
@@ -21,7 +21,7 @@ class SiteLaunched extends Event {
 		$this->data   = array(
 			'ttl' => $this->getInstallTime(),
 		);
-		
+
 		return $this->sendEvent();
 	}
 


### PR DESCRIPTION
This ticket aims to address this internal ticket: https://jira.newfold.com/projects/PRESS1/issues/PRESS1-122

The ticket asks that on plugin deactivation, we should:

1. Check if coming soon is already on.
2. Send `site_launched` event.
3. Disable coming soon (database option).
4. Deactivate.

I initially added the code to do the above entirely, but as I was testing, I found out that the data module already sends the `site_launched` event upon `mm_coming_soon` value change to 'false' https://github.com/newfold-labs/wp-module-data/blob/main/includes/Listeners/BluehostPlugin.php#L39-L52

So, just disabling coming soon is enough to send the event. However, I kept the event code on there but commented out the function call since the code in this can be used later for future events.

Open to ideas as well.