### PR TITLE
Always reactivate the plugin after tests

### DIFF
--- a/tests/cypress/integration/deactivation-survey.cy.js
+++ b/tests/cypress/integration/deactivation-survey.cy.js
@@ -131,12 +131,14 @@ describe( 'Plugin Deactivation Survey', () => {
 			url: /newfold-notifications/,
 		}, { body: {} });
 
-		cy.get('.activate a[id*="' + Cypress.env('pluginId') + '"]').then(($activateButton) => {
-			var href = $activateButton.attr('href');
-			if(href) {
-				cy.visit('/wp-admin/' + href);
-			}
-		})
+		if(cy.find('.activate a[id*="' + Cypress.env('pluginId') + '"]')) {
+			cy.get('.activate a[id*="' + Cypress.env('pluginId') + '"]').then(($activateButton) => {
+				var href = $activateButton.attr('href');
+				if (href) {
+					cy.visit('/wp-admin/' + href);
+				}
+			})
+		}
 		cy.get('.deactivate a[id*="' + Cypress.env('pluginId') + '"]').should('exist');
 	});
 } );

--- a/tests/cypress/integration/deactivation-survey.cy.js
+++ b/tests/cypress/integration/deactivation-survey.cy.js
@@ -78,11 +78,6 @@ describe( 'Plugin Deactivation Survey', () => {
 		cy.get( '.activate a[id*="' + Cypress.env( 'pluginId' ) + '"]' ).should(
 			'exist'
 		);
-		// reactivate plugin
-		cy.get(
-			'.activate a[id*="' + Cypress.env( 'pluginId' ) + '"]'
-		).click();
-		cy.wait( 500 );
 	} );
 
 	it( 'Survey successfully deactivates plugin', () => {
@@ -123,10 +118,25 @@ describe( 'Plugin Deactivation Survey', () => {
 		cy.get( '.activate a[id*="' + Cypress.env( 'pluginId' ) + '"]' ).should(
 			'exist'
 		);
-		// reactivate plugin
-		cy.get(
-			'.activate a[id*="' + Cypress.env( 'pluginId' ) + '"]'
-		).click();
-		cy.wait( 500 );
 	} );
+
+	// Reactivate plugin after each test.
+	// This function will always run, even when a test fails.
+	afterEach(() => {
+		cy.visit('/wp-admin/plugins.php');
+
+		// ignore notifications errors if there are any
+		cy.intercept({
+			method: 'GET',
+			url: /newfold-notifications/,
+		}, { body: {} });
+
+		cy.get('.activate a[id*="' + Cypress.env('pluginId') + '"]').then(($activateButton) => {
+			var href = $activateButton.attr('href');
+			if(href) {
+				cy.visit('/wp-admin/' + href);
+			}
+		})
+		cy.get('.deactivate a[id*="' + Cypress.env('pluginId') + '"]').should('exist');
+	});
 } );


### PR DESCRIPTION
Moves the activate plugin code from the end of each test case into the `afterEach()` method.

Otherwise, when an individual test fails, the plugin is not reactivated and subsequent tests fail where they expect it to be loaded. `afterEach()` always runs, like try-catch-finally.

Cypress highlights this as [an anti-pattern in their best practices guide](https://docs.cypress.io/guides/references/best-practices#Using-after-Or-afterEach-Hooks). It should be done in a `before`/`beforeEach` but that would require updating all test suites which could possibly run after this one.