### PR TITLE
Force plugin reactivation after tests

### DIFF
--- a/tests/cypress/integration/deactivation-survey.cy.js
+++ b/tests/cypress/integration/deactivation-survey.cy.js
@@ -130,3 +130,7 @@ describe( 'Plugin Deactivation Survey', () => {
 		cy.wait( 500 );
 	} );
 } );
+
+after(()=>{
+	cy.exec( `npx wp-env run cli wp plugin activate ${ Cypress.env( 'pluginSlug' ) }` );
+});


### PR DESCRIPTION
Add and after statement that runs a cli command to activate the plugin - in case there was an issue with the test and the plugin wasn't reactivated via the test. So the remaining tests don't all fail.

This command requires plugin cypress config to add a `pluginSlug` env var so the command can know which plugin to activate. So we'll need to add that to each plugin.

Edit - to force tests to run again after adding PluginSlug to Bluehost and Hostgator plugins.