### PR TITLE
Add an "Are you sure" interstitial

### DIFF
--- a/includes/DeactivationSurvey.php
+++ b/includes/DeactivationSurvey.php
@@ -7,6 +7,7 @@
 
 namespace NewfoldLabs\WP\Module\Deactivation;
 
+use NewfoldLabs\WP\ModuleLoader\Container;
 use function NewfoldLabs\WP\ModuleLoader\container;
 
 /**
@@ -18,6 +19,53 @@ class DeactivationSurvey {
 	 * DeactivationSurvey constructor.
 	 */
 	public function __construct() {
+		// $this->container = $container;
+
+		$defaults = array(
+			'surveyAriaTitle'   => __( 'Plugin Deactivation Survey', 'wp-module-deactivation' ),
+			'surveyTitle'       => sprintf( __( 'Thank you for using the %s plugin!', 'wp-module-deactivation' ), ucwords( container()->plugin()->id ) ),
+			'surveyDesc'        => __( 'Please take a moment to let us know why you\'re deactivating this plugin.', 'wp-module-deactivation' ),
+			'formAriaLabel'     => __( 'Plugin Deactivation Form', 'wp-module-deactivation' ),
+			'label'             => __( 'Why are you deactivating this plugin?', 'wp-module-deactivation' ),
+			'placeholder'       => __( 'Please share the reason here...', 'wp-module-deactivation' ),
+			'submit'            => __( 'Submit & Deactivate', 'wp-module-deactivation' ),
+			'submitAriaLabel'   => __( 'Submit and Deactivate Plugin', 'wp-module-deactivation' ),
+			'cancel'            => __( 'Cancel', 'wp-module-deactivation' ),
+			'cancelAriaLabel'   => __( 'Cancel Deactivation', 'wp-module-deactivation' ),
+			'skip'              => __( 'Skip & Deactivate', 'wp-module-deactivation' ),
+			'skipAriaLabel'     => __( 'Skip and Deactivate Plugin', 'wp-module-deactivation' ),
+			'continue'          => __( 'Continue', 'wp-module-deactivation' ),
+			'continueAriaLabel' => __( 'Continue Deactivation', 'wp-module-deactivation' ),
+			'sureTitle'         => __( 'Are You Sure?', 'wp-module-deactivation' ),
+			'sureDesc'          => __( 'This plugin is powers important features on your site. These will no longer be available if you deactivate the plugin.', 'wp-module-deactivation' ),
+			'sureHelpTitle'     => __( 'Need Help?', 'wp-module-deactivation' ),
+			'sureHelpUrl1'      => 'https://bluehost.com/',
+			'sureHelpUrl2'      => 'https://bluehost.com/',
+			'sureHelpUrl3'      => 'https://bluehost.com/',
+			'sureCards'         => array(
+				__( 'Performance Improvements' ),
+				__( 'Wonder Blocks Patters' ),
+				__( 'Security Improvements' ),
+				__( 'Integrated AI Help Center' ),
+			),
+		);
+
+		$defaults['sureHelp'] = sprintf( 
+			__( 'Learn more about <a href="%1$s" target="_blank" nfd-deactivation-survey-destroy>the features of this plugin</a>, check the <a href="%2$s" onclick="newfoldEmbeddedHelp.toggleNFDLaunchedEmbeddedHelp()">help center</a>, or <a href="%3$s">contact support</a>.' ),
+			$defaults['sureHelpUrl1'],
+			$defaults['sureHelpUrl2'],
+			$defaults['sureHelpUrl3']
+		);
+
+		// Merge defaults with container values from plugin
+		// $this->strings = wp_parse_args(
+		// 	$container->has( 'deactivation' ) ? 
+		// 	$container['deactivation'] : 
+		// 	array(), 
+		// 	$defaults
+		// );
+		$this->strings = $defaults;
+
 		$this->deactivation_survey_assets();
 		$this->deactivation_survey_runtime();
 	}
@@ -68,21 +116,7 @@ class DeactivationSurvey {
 				'restApiNonce'   => wp_create_nonce( 'wp_rest' ),
 				'brand'          => container()->plugin()->id,
 				'pluginSlug'     => $plugin_slug,
-				'strings'        => array(
-					'surveyTitle'     => __( 'Plugin Deactivation Survey', 'wp-module-deactivation' ),
-					'dialogTitle'     => sprintf( __( 'Thank you for using the %s plugin!', 'wp-module-deactivation' ), ucwords( container()->plugin()->id ) ),
-					'dialogDesc'      => __( 'Please take a moment to let us know why you\'re deactivating this plugin.', 'wp-module-deactivation' ),
-					'formAriaLabel'   => __( 'Plugin Deactivation Form', 'wp-module-deactivation' ),
-					'label'           => __( 'Why are you deactivating this plugin?', 'wp-module-deactivation' ),
-					'placeholder'     => __( 'Please share the reason here...', 'wp-module-deactivation' ),
-					'submit'          => __( 'Submit & Deactivate', 'wp-module-deactivation' ),
-					'submitAriaLabel' => __( 'Submit and Deactivate Plugin', 'wp-module-deactivation' ),
-					'cancel'          => __( 'Cancel', 'wp-module-deactivation' ),
-					'cancelAriaLabel' => __( 'Cancel Deactivation', 'wp-module-deactivation' ),
-					'skip'            => __( 'Skip & Deactivate', 'wp-module-deactivation' ),
-					'skipAriaLabel'   => __( 'Skip and Deactivate Plugin', 'wp-module-deactivation' ),
-					'sureTitle'       => __( 'Are You Sure?', 'wp-module-deactivation' ),
-				),
+				'strings'        => $this->strings,
 			)
 		);
 	}

--- a/includes/DeactivationSurvey.php
+++ b/includes/DeactivationSurvey.php
@@ -81,6 +81,7 @@ class DeactivationSurvey {
 					'cancelAriaLabel' => __( 'Cancel Deactivation', 'wp-module-deactivation' ),
 					'skip'            => __( 'Skip & Deactivate', 'wp-module-deactivation' ),
 					'skipAriaLabel'   => __( 'Skip and Deactivate Plugin', 'wp-module-deactivation' ),
+					'sureTitle'       => __( 'Are You Sure?', 'wp-module-deactivation' ),
 				),
 			)
 		);

--- a/includes/DeactivationSurvey.php
+++ b/includes/DeactivationSurvey.php
@@ -23,7 +23,10 @@ class DeactivationSurvey {
 
 		$defaults = array(
 			'surveyAriaTitle'   => __( 'Plugin Deactivation Survey', 'wp-module-deactivation' ),
-			'surveyTitle'       => sprintf( __( 'Thank you for using the %s plugin!', 'wp-module-deactivation' ), ucwords( container()->plugin()->id ) ),
+			'surveyTitle'       => sprintf( 
+				__( 'Thank you for using the %s plugin!', 'wp-module-deactivation' ), 
+				ucwords( container()->plugin()->id )
+			),
 			'surveyDesc'        => __( 'Please take a moment to let us know why you\'re deactivating this plugin.', 'wp-module-deactivation' ),
 			'formAriaLabel'     => __( 'Plugin Deactivation Form', 'wp-module-deactivation' ),
 			'label'             => __( 'Why are you deactivating this plugin?', 'wp-module-deactivation' ),
@@ -36,25 +39,40 @@ class DeactivationSurvey {
 			'skipAriaLabel'     => __( 'Skip and Deactivate Plugin', 'wp-module-deactivation' ),
 			'continue'          => __( 'Continue', 'wp-module-deactivation' ),
 			'continueAriaLabel' => __( 'Continue Deactivation', 'wp-module-deactivation' ),
-			'sureTitle'         => __( 'Are You Sure?', 'wp-module-deactivation' ),
-			'sureDesc'          => __( 'This plugin is powers important features on your site. These will no longer be available if you deactivate the plugin.', 'wp-module-deactivation' ),
-			'sureHelpTitle'     => __( 'Need Help?', 'wp-module-deactivation' ),
-			'sureHelpUrl1'      => 'https://bluehost.com/',
-			'sureHelpUrl2'      => 'https://bluehost.com/',
-			'sureHelpUrl3'      => 'https://bluehost.com/',
+			'sureTitle'         => __( 'Are you sure you want to deactivate?', 'wp-module-deactivation' ),
+			'sureDesc'          => __( 'If the Bluehost plugin is deactivated, these features will no longer work:', 'wp-module-deactivation' ),
 			'sureCards'         => array(
-				__( 'Performance Improvements' ),
-				__( 'Wonder Blocks Patters' ),
-				__( 'Security Improvements' ),
-				__( 'Integrated AI Help Center' ),
+				array(
+					'title' => sprintf( 
+						__( '%s Caching', 'wp-module-deactivation' ), 
+						ucwords( container()->plugin()->id )
+					),
+					'desc'  => __( 'Automatically clears the server page cache when your site updates', 'wp-module-deactivation' ),
+					'condition' => true,
+				),
+				array(
+					'title' => sprintf(
+						__( '%s Staging', 'wp-module-deactivation' ), 
+						ucwords( container()->plugin()->id )
+					),
+					'desc'  => __( 'Create a staging copy of your site to safely test changes', 'wp-module-deactivation' ),
+					'condition' => true,
+				),
+				array(
+					'title' => __( 'WooCommerce Tools', 'wp-module-deactivation' ),
+					'desc'  => __( 'Run campaigns and promotions on your store', 'wp-module-deactivation' ),
+					'condition' => 'window.NewfoldRuntime.isWoocommerceActive',
+				),
+				array(
+					'title' => __( 'Wonder Blocks & Patterns Library', 'wp-module-deactivation' ),
+					'desc'  => __( 'Dozens of beautiful block templates and patterns', 'wp-module-deactivation' ),
+					'condition' => true,
+				),
 			),
-		);
-
-		$defaults['sureHelp'] = sprintf( 
-			__( 'Learn more about <a href="%1$s" target="_blank" nfd-deactivation-survey-destroy>the features of this plugin</a>, check the <a href="%2$s" onclick="newfoldEmbeddedHelp.toggleNFDLaunchedEmbeddedHelp()">help center</a>, or <a href="%3$s">contact support</a>.' ),
-			$defaults['sureHelpUrl1'],
-			$defaults['sureHelpUrl2'],
-			$defaults['sureHelpUrl3']
+			'sureHelp'     => sprintf( 
+				__( 'Need Help? Check the <a href="%s">help center</a> for support.', 'wp-module-deactivation' ),
+				'/wp-admin/admin.php?page=' . container()->plugin()->id . '#/help'
+			),
 		);
 
 		// Merge defaults with container values from plugin
@@ -107,6 +125,8 @@ class DeactivationSurvey {
 	 */
 	public function deactivation_survey_runtime() {
 		$plugin_slug = explode( '/', container()->plugin()->basename )[0];
+
+		// Validate strings->cards via condition
 
 		wp_localize_script(
 			'nfd-deactivation-survey',

--- a/static/css/deactivation-survey.css
+++ b/static/css/deactivation-survey.css
@@ -146,15 +146,23 @@
 
 
 .nfd-deactivation-fieldset {
+    border-top: 1px solid #dcdcde;
     display: flex;
     flex-direction: column;
     margin: 0 auto;
     max-width: 800px;
+    padding-top: 1rem;
     text-align: left;
-    gap: .5rem;
+    gap: .75rem;
 }
 
+.nfd-deactivation-label {
+    font-size: 1rem;
+    font-weight: 600;
+}
 .nfd-deactivation-textarea {
+    font-size: 1rem;
+    padding: .5em;
     min-height: 10vh;
     width: 100%;
 }

--- a/static/css/deactivation-survey.css
+++ b/static/css/deactivation-survey.css
@@ -57,15 +57,6 @@
     width: 80vw;
 }
 
-@media screen and (max-width: 600px) {
-    .nfd-deactivation-survey__container,
-    .nfd-deactivation-survey__container[data-step="1"] {
-        max-height: 100vh;
-        max-width: 100vw;
-        width: 100%;
-    }
-}
-
 .nfd-deactivation__content {
     align-items: center;
     background-color: #f9f9f6;
@@ -81,21 +72,20 @@
 
 .nfd-deactivation__header,
 .nfd-deactivation__body,
-.nfd-deactivation__footer-content {
+.nfd-deactivation__footer-content,
+.nfd-deactivation-fieldset {
+    padding: 0 4rem;
     margin: 0 auto;
-    max-width: 800px;
+    max-width: 90%;
 }
 
 .nfd-deactivation__header {
-    padding: 0 4rem;
-    margin-bottom: 1rem;
     margin-top: 2rem;
     text-align: center;
     width: 100%;
 }
 
 .nfd-deactivation__body {
-    padding: 0 4rem;
     margin: 1rem auto;
     text-align: left;
     width: 100%;
@@ -109,7 +99,8 @@
 }
 
 .nfd-deactivation__footer-content {
-    padding: 1rem 4rem;
+    padding-top: .5rem;
+    padding-bottom: .5rem
 }
 
 .nfd-deactivation__content-title {
@@ -133,24 +124,35 @@
 }
 
 .nfd-deactivation__card {
+    align-items: center;
     background-color: #fff;
     border: none;
     border-radius: 3px;
     box-shadow: 0 0 15px #e2e2df;
-    font-size: 1.25rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+    justify-content: left;
     margin: 0 auto 1rem;
     max-width: 100%;
     padding: 1rem 2rem;
     text-align: left;
 }
 
+.nfd-deactivation__card-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #111111;
+}
+
+.nfd-deactivation__card-desc {
+    color: #000000;
+}
 
 .nfd-deactivation-fieldset {
     border-top: 1px solid #dcdcde;
     display: flex;
     flex-direction: column;
-    margin: 0 auto;
-    max-width: 800px;
     padding-top: 1rem;
     text-align: left;
     gap: .75rem;
@@ -264,6 +266,23 @@
     position: absolute;
     top: 0;
     width: 20%;
+}
+
+/* mobile */
+@media screen and (max-width: 600px) {
+    .nfd-deactivation-survey__container,
+    .nfd-deactivation-survey__container[data-step="1"] {
+        max-height: 100vh;
+        max-width: 100vw;
+        width: 100%;
+    }
+
+    .nfd-deactivation__header,
+    .nfd-deactivation__body,
+    .nfd-deactivation__footer-content,
+    .nfd-deactivation-fieldset {
+        padding: 0 2rem;
+    }
 }
 
 /* animations */

--- a/static/css/deactivation-survey.css
+++ b/static/css/deactivation-survey.css
@@ -13,10 +13,14 @@
 /* End utility classes */
 
 #nfd-deactivation-survey {
-    z-index: 100000;
+    align-items: center;
     display: flex;
     justify-content: center;
-    align-items: center;
+    z-index: 100000;
+}
+
+#nfd-deactivation-survey * {
+    box-sizing: border-box;
 }
 
 #nfd-deactivation-survey[aria-hidden="true"] {
@@ -26,16 +30,16 @@
 #nfd-deactivation-survey,
 .nfd-deactivation-survey__overlay,
 .nfd-deactivation-survey__disabled {
-    position: fixed;
-    top: 0;
-    right: 0;
     bottom: 0;
     left: 0;
+    position: fixed;
+    right: 0;
+    top: 0;
 }
 
 .nfd-deactivation-survey__overlay {
-    background-color: rgba(43, 46, 56, 0.9);
     animation: nfd-fade-in 200ms both;
+    background-color: rgba(43, 46, 56, 0.9);
 }
 
 .nfd-deactivation-survey__disabled {
@@ -43,52 +47,144 @@
 }
 
 .nfd-deactivation-survey__container {
-    position: relative;
+    animation: nfd-fade-in 400ms 200ms both, nfd-slide-up 400ms 200ms both;
     background-color: white;
+    border-radius: 5px;
     color: #3C434A;
     max-height: 80vh;
-    width: 600px;
-    max-width: 80vw;
-    padding: 1.5rem;
-    border-radius: 5px;
-    animation: nfd-fade-in 400ms 200ms both, nfd-slide-up 400ms 200ms both;
+    max-width: 1024px;
+    position: relative;
+    width: 80vw;
 }
 
+@media screen and (max-width: 600px) {
+    .nfd-deactivation-survey__container,
+    .nfd-deactivation-survey__container[data-step="1"] {
+        max-height: 100vh;
+        max-width: 100vw;
+        width: 100%;
+    }
+}
+
+.nfd-deactivation__content {
+    align-items: center;
+    background-color: #f9f9f6;
+    display:flex;
+    flex-direction: column;
+    justify-content: space-between;
+    text-align: center;
+}
+
+.nfd-deactivation-form {
+    width: 100%;
+}
+
+.nfd-deactivation__header,
+.nfd-deactivation__body,
+.nfd-deactivation__footer-content {
+    margin: 0 auto;
+    max-width: 800px;
+}
+
+.nfd-deactivation__header {
+    padding: 0 4rem;
+    margin-bottom: 1rem;
+    margin-top: 2rem;
+    text-align: center;
+    width: 100%;
+}
+
+.nfd-deactivation__body {
+    padding: 0 4rem;
+    margin: 1rem auto;
+    text-align: left;
+    width: 100%;
+}
+
+.nfd-deactivation__footer {
+    background-color: #fff;
+    border-top: 1px solid #dcdcde;
+    margin-top: 1rem;
+    width: 100%;
+}
+
+.nfd-deactivation__footer-content {
+    padding: 1rem 4rem;
+}
+
+.nfd-deactivation__content-title {
+    font-size: 2.5rem;
+    line-height: 1.1em;
+}
+
+.nfd-deactivation__content-subtitle {
+    font-size: 1.25rem;
+    line-height: 1.25em;
+}
+
+.nfd-deactivation__helptext {
+    font-size: 1.0rem;
+    padding-right: 3rem;
+    text-align: left;
+}
+
+.nfd-deactivation-survey__content {
+    padding: 1.5rem;
+}
+
+.nfd-deactivation__card {
+    background-color: #fff;
+    border: none;
+    border-radius: 3px;
+    box-shadow: 0 0 15px #e2e2df;
+    font-size: 1.25rem;
+    margin: 0 auto 1rem;
+    max-width: 100%;
+    padding: 1rem 2rem;
+    text-align: left;
+}
+
+
+.nfd-deactivation-fieldset {
+    display: flex;
+    flex-direction: column;
+    margin: 0 auto;
+    max-width: 800px;
+    text-align: left;
+    gap: .5rem;
+}
+
+.nfd-deactivation-textarea {
+    min-height: 10vh;
+    width: 100%;
+}
+
+
 .nfd-deactivation-survey__container button[aria-label="Close dialog"] {
-    position: absolute;
-    top: 5px;
-    right: 5px;
-    padding: .5rem;
     border: none;
     background-color: transparent;
     color: #3C434A;
     cursor: pointer;
     font-size: 1.75rem;
     line-height: unset;
-}
-
-.nfd-deactivation-survey__content-header {
-    padding-bottom: .85rem;
-    border-bottom: 1px solid #E5E5E5;
+    padding: .5rem;
+    position: absolute;
+    right: 5px;
+    top: 5px;
 }
 
 .nfd-deactivation-survey__content-header h3 {
-    margin: 0 0 .45rem;
-    font-size: 1rem;
     color: #3C434A;
-}
-
-.nfd-deactivation-survey__content-header p {
-    margin: 0;
-    font-size: .85rem;
+    font-size: 1rem;
+    margin: 0 0 .45rem;
 }
 
 .nfd-deactivation-survey__content form {
     display: flex;
     flex-direction: column;
-    width: 100%;
-    margin-top: 1.5rem;
     gap: 1rem;
+    margin-top: 1.5rem;
+    width: 100%;
 }
 
 .nfd-deactivation-survey__content form label {
@@ -97,11 +193,11 @@
 }
 
 .nfd-deactivation-survey__content form textarea {
-    width: 100%;
     border-color: #8B8F94;
-    padding: 8px;
-    min-height: 60px;
     max-height: 150px;
+    min-height: 60px;
+    padding: 8px;
+    width: 100%;
 }
 
 .nfd-deactivation-survey__content form textarea::placeholder {
@@ -109,25 +205,25 @@
 }
 
 .nfd-deactivation-survey__content-actions {
-    display: flex;
-    justify-content: space-between;
     align-items: center;
+    display: flex;
     gap: 1rem;
+    justify-content: space-between;
 }
 
 .nfd-deactivation-survey__content-actions > div {
-    display: flex;
     align-items: center;
+    display: flex;
     gap: .75rem;
 }
 
 .nfd-deactivation-survey-action {
-    color: #525354;
     background-color: transparent;
-    padding: 2px;
     border: none;
-    text-decoration: unset;
+    color: #525354;
     cursor: pointer;
+    padding: 2px;
+    text-decoration: unset;
 }
 
 .nfd-deactivation-survey-action:hover {
@@ -139,27 +235,27 @@
 }
 
 .nfd-deactivation-survey_loading {
-    width: 100%;
-    height: 4.8px;
-    display: inline-block;
-    position: relative;
     background: #e5ebf0;
     border-radius: 99px;
-    overflow: hidden;
+    display: inline-block;
+    height: 4.8px;
     margin-top: 1rem;
+    overflow: hidden;
+    position: relative;
+    width: 100%;
 }
 
 .nfd-deactivation-survey_loading::after {
-    content: '';
-    width: 20%;
-    height: 4.8px;
+    animation: nfd-submitting 1.5s linear infinite;
     background: #2270B1;
+    border-radius: 99px;
+    box-sizing: border-box;
+    content: '';
+    height: 4.8px;
+    left: 0;
     position: absolute;
     top: 0;
-    left: 0;
-    box-sizing: border-box;
-    animation: nfd-submitting 1.5s linear infinite;
-    border-radius: 99px;
+    width: 20%;
 }
 
 /* animations */
@@ -191,4 +287,3 @@
         flex-direction: column;
     }
 }
-  

--- a/static/js/deactivation-survey.js
+++ b/static/js/deactivation-survey.js
@@ -1,190 +1,259 @@
 {
-    // Data module runtime data
-    const runtimeData = window.newfoldDeactivationSurvey;
-    // Dialog instance / will be initialized later
-    let deactivationSurveyDialog;
+	// Data module runtime data
+	const runtimeData = window.newfoldDeactivationSurvey;
+	// Dialog instance / will be initialized later
+	let deactivationSurveyDialog;
 
-    const renderDialog = () => {
-        // Create dialog container
-        const surveyDialog = document.createElement('div');
-        surveyDialog.id = 'nfd-deactivation-survey';
-        surveyDialog.setAttribute('aria-labelledby', 'nfd-deactivation-survey-title');
-        surveyDialog.setAttribute('aria-hidden', 'true');
-        surveyDialog.innerHTML = getDialogHTML();
+	const renderDialog = () => {
+		// Create dialog container
+		const surveyDialog = document.createElement( 'div' );
+		surveyDialog.id = 'nfd-deactivation-survey';
+		surveyDialog.setAttribute(
+			'aria-labelledby',
+			'nfd-deactivation-survey-title'
+		);
+		surveyDialog.setAttribute( 'aria-hidden', 'true' );
+		surveyDialog.innerHTML = getDialogHTML();
 
-        // Append dialog container to DOM
-        const wpAdmin = document.querySelector('body.wp-admin');
-        wpAdmin.appendChild(surveyDialog);
+		// Append dialog container to DOM
+		const wpAdmin = document.querySelector( 'body.wp-admin' );
+		wpAdmin.appendChild( surveyDialog );
 
-        // Disable body scroll
-        document.body.classList.add('nfd-noscroll');
+		// Disable body scroll
+		document.body.classList.add( 'nfd-noscroll' );
 
-        // Create dialog instance
-        deactivationSurveyDialog = new A11yDialog(surveyDialog);
-        deactivationSurveyDialog.show();
-    }
+		// Create dialog instance
+		deactivationSurveyDialog = new A11yDialog( surveyDialog );
+		deactivationSurveyDialog.show();
+	};
 
-    const getDialogHTML = () => {
-        const dialogHTML = `
-        <div class="nfd-deactivation-survey__overlay" nfd-deactivation-survey-destroy></div>
-        <div class="nfd-deactivation-survey__container" role="document">
-            <div class="nfd-deactivation-survey__content">
-                <h1 id="nfd-deactivation-survey-title" class="nfd-hidden" aria-hidden="true">${runtimeData.strings.surveyTitle}</h1>
-                <div class="nfd-deactivation-survey__content-header">
-                    <h3>${runtimeData.strings.dialogTitle}</h3>
-                    <p>${runtimeData.strings.dialogDesc}</p>
+	const getSureContent = () => {
+		const content = `
+			<div class="nfd-deactivation-sure__content">
+                <h1 id="nfd-deactivation-sure-title">${ runtimeData.strings.sureTitle }</h1>
+                <div class="nfd-deactivation-sure__content-header">
+                    <p>This plugin is currently powering features on your site. If you deactivate, these features will no longer be available.</p>
+                    <ul style="list-style: disc; list-style-position: inside;">
+						<li>Integrations with your hosting</li>
+						<li>Performance Improvements</li>
+						<li>Wonder Blocks</li>
+					</ul>
+
+					<div class="nfd-deactivation-survey__content-actions">
+						<div>
+							<button type="button" nfd-deactivation-survey-next class="nfd-button nfd-button-seconday nfd-deactivation-survey-action" aria-label="${ runtimeData.strings.submitAriaLabel }">Continue</button>
+							<button type="button" class="nfd-button nfd-button-primary nfd-deactivation-survey-action" nfd-deactivation-survey-destroy aria-label="${ runtimeData.strings.cancelAriaLabel }">${ runtimeData.strings.cancel }</button>
+						</div>
+					</div>
                 </div>
-                ${getSurveyFormHTML()}
+            </div>
+		`;
+		return content;
+	};
+
+	const getSurveyContent = () => {
+		const content = `
+			<div class="nfd-deactivation-survey__content nfd-hidden" aria-hidden="true">
+                <h1 id="nfd-deactivation-survey-title" class="nfd-hidden" aria-hidden="true">${
+					runtimeData.strings.surveyTitle
+				}</h1>
+                <div class="nfd-deactivation-survey__content-header">
+                    <h3>${ runtimeData.strings.dialogTitle }</h3>
+                    <p>${ runtimeData.strings.dialogDesc }</p>
+                </div>
+                ${ getSurveyFormHTML() }
                 <span class="nfd-deactivation-survey_loading nfd-hidden"></span>
             </div>
-        </div>
-        <div class="nfd-deactivation-survey__disabled nfd-hidden"></div>
+		`;
+		return content;
+	};
+
+	const getDialogHTML = () => {
+		const content = `
+			<div class="nfd-deactivation-survey__overlay" nfd-deactivation-survey-destroy></div>
+			<div class="nfd-deactivation-survey__container" role="document">
+				${ getSureContent() }
+				${ getSurveyContent() }
+			</div>
+			<div class="nfd-deactivation-survey__disabled nfd-hidden"></div>
         `;
-        return dialogHTML;
-    }
+		return content;
+	};
 
-    const getSurveyFormHTML = () => {
-        return `
-        <form aria-label="${runtimeData.strings.formAriaLabel}">
-            <fieldset>
-                <label for="nfd-deactivation-survey__input">${runtimeData.strings.label}</label>
-                <textarea id="nfd-deactivation-survey__input" placeholder="${runtimeData.strings.placeholder}"></textarea>
-            </fieldset>
-            <div class="nfd-deactivation-survey__content-actions">
-                <div>
-                    <input type="submit" value="${runtimeData.strings.submit}" nfd-deactivation-survey-submit class="button button-primary" aria-label="${runtimeData.strings.submitAriaLabel}"/>
-                    <button type="button" class="nfd-deactivation-survey-action" nfd-deactivation-survey-destroy aria-label="${runtimeData.strings.cancelAriaLabel}">${runtimeData.strings.cancel}</button>
-                </div>
-                <div>
-                    <button type="button" class="nfd-deactivation-survey-action" nfd-deactivation-survey-skip aria-label="${runtimeData.strings.skipAriaLabel}">${runtimeData.strings.skip}</button>
-                </div>
-            </div>
-        </form>
+	const getSurveyFormHTML = () => {
+		const content = `
+			<form aria-label="${ runtimeData.strings.formAriaLabel }">
+				<fieldset>
+					<label for="nfd-deactivation-survey__input">${ runtimeData.strings.label }</label>
+					<textarea id="nfd-deactivation-survey__input" placeholder="${ runtimeData.strings.placeholder }"></textarea>
+				</fieldset>
+				<div class="nfd-deactivation-survey__content-actions">
+					<div>
+						<input type="submit" value="${ runtimeData.strings.submit }" nfd-deactivation-survey-submit class="button button-primary" aria-label="${ runtimeData.strings.submitAriaLabel }"/>
+						<button type="button" class="nfd-deactivation-survey-action" nfd-deactivation-survey-destroy aria-label="${ runtimeData.strings.cancelAriaLabel }">${ runtimeData.strings.cancel }</button>
+					</div>
+					<div>
+						<button type="button" class="nfd-deactivation-survey-action" nfd-deactivation-survey-skip aria-label="${ runtimeData.strings.skipAriaLabel }">${ runtimeData.strings.skip }</button>
+					</div>
+				</div>
+			</form>
         `;
-    }
+		return content;
+	};
 
-    const destroyDialog = () => {
-        // Destroy dialog instance
-        deactivationSurveyDialog.destroy();
-        deactivationSurveyDialog = null;
+	const destroyDialog = () => {
+		// Destroy dialog instance
+		deactivationSurveyDialog.destroy();
+		deactivationSurveyDialog = null;
 
-        // Remove dialog container from DOM if exists
-        const dialog = document.getElementById('nfd-deactivation-survey');
-        if (dialog) {
-            dialog.remove();
-        }
+		// Remove dialog container from DOM if exists
+		const dialog = document.getElementById( 'nfd-deactivation-survey' );
+		if ( dialog ) {
+			dialog.remove();
+		}
 
-        // Enable body scroll
-        document.body.classList.remove('nfd-noscroll');
-    }
+		// Enable body scroll
+		document.body.classList.remove( 'nfd-noscroll' );
+	};
 
-    const deactivatePlugin = () => {
-        destroyDialog();
-        // Get deactivation link and redirect
-        const deactivateLink = document.getElementById('deactivate-' + runtimeData.pluginSlug).href;
-        if (deactivateLink) {
-            window.location.href = deactivateLink;
-        } else {
-            console.error('Error: Deactivation link not found.');
-        }
-    }
+	const deactivatePlugin = () => {
+		destroyDialog();
+		// Get deactivation link and redirect
+		const deactivateLink = document.getElementById(
+			'deactivate-' + runtimeData.pluginSlug
+		).href;
+		if ( deactivateLink ) {
+			window.location.href = deactivateLink;
+		} else {
+			console.error( 'Error: Deactivation link not found.' );
+		}
+	};
 
-    const isSubmitting = () => {
-        // Disable actions while submitting
-        const dialogDisabledOverlay = document.querySelector('.nfd-deactivation-survey__disabled');
-        dialogDisabledOverlay.classList.remove('nfd-hidden');
-        const dialogLoading = document.querySelector('.nfd-deactivation-survey_loading');
-        dialogLoading.classList.remove('nfd-hidden');
-        const actionsBtns = [
-            ...document.querySelectorAll('.nfd-deactivation-survey-action'),
-            document.querySelector('#nfd-deactivation-survey form input[type="submit"]'),
-        ];
-        actionsBtns.forEach(btn => {
-            btn.setAttribute('disabled', 'true');
-        });
+	const isSubmitting = () => {
+		// Disable actions while submitting
+		const dialogDisabledOverlay = document.querySelector(
+			'.nfd-deactivation-survey__disabled'
+		);
+		dialogDisabledOverlay.classList.remove( 'nfd-hidden' );
+		const dialogLoading = document.querySelector(
+			'.nfd-deactivation-survey_loading'
+		);
+		dialogLoading.classList.remove( 'nfd-hidden' );
+		const actionsBtns = [
+			...document.querySelectorAll( '.nfd-deactivation-survey-action' ),
+			document.querySelector(
+				'#nfd-deactivation-survey form input[type="submit"]'
+			),
+		];
+		actionsBtns.forEach( ( btn ) => {
+			btn.setAttribute( 'disabled', 'true' );
+		} );
 
-        // disbale ESC key while submitting
-        deactivationSurveyDialog.on('show', () => {
-            deactivationSurveyDialog.off('keydown');
-        });
-    }
+		// disbale ESC key while submitting
+		deactivationSurveyDialog.on( 'show', () => {
+			deactivationSurveyDialog.off( 'keydown' );
+		} );
+	};
 
-    const submitSurvey = async (skipped = false) => {
-        isSubmitting();
+	const submitSurvey = async ( skipped = false ) => {
+		isSubmitting();
 
-        let surveyInput = 'No input';
-        if (!skipped) {
-            inputValue = document.getElementById('nfd-deactivation-survey__input').value;
-            if (inputValue.length > 0) {
-                surveyInput = inputValue;
-            }
-        }
+		let surveyInput = 'No input';
+		if ( ! skipped ) {
+			const inputValue = document.getElementById(
+				'nfd-deactivation-survey__input'
+			).value;
+			if ( inputValue.length > 0 ) {
+				surveyInput = inputValue;
+			}
+		}
 
-        // Send event
-        const send = await sendEvent(surveyInput);
-        deactivatePlugin();
-    }
+		// Send event
+		const send = await sendEvent( surveyInput );
+		deactivatePlugin();
+	};
 
-    const sendEvent = async (surveyInput) => {
-        let eventData = {
-            'label_key': 'survey_input',
-            'survey_input': surveyInput,
-            'category': 'user_action',
-            'brand': runtimeData.brand,
-            'page': window.location.href
-        }
+	const sendEvent = async ( surveyInput ) => {
+		const eventData = {
+			label_key: 'survey_input',
+			survey_input: surveyInput,
+			category: 'user_action',
+			brand: runtimeData.brand,
+			page: window.location.href,
+		};
 
-        // Attach abTestPluginHome flag value if exists
-        if (typeof getABTestPluginHome() === 'boolean') {
-            eventData.abTestPluginHome = getABTestPluginHome();
-        }
+		// Attach abTestPluginHome flag value if exists
+		if ( typeof getABTestPluginHome() === 'boolean' ) {
+			eventData.abTestPluginHome = getABTestPluginHome();
+		}
 
-        await fetch(runtimeData.eventsEndpoint, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-WP-Nonce': runtimeData.restApiNonce
-            },
-            body: JSON.stringify({
-                action: 'deactivation_survey_freeform',
-                data: eventData
-            })
-        });
-        return true;
-    }
+		await fetch( runtimeData.eventsEndpoint, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-WP-Nonce': runtimeData.restApiNonce,
+			},
+			body: JSON.stringify( {
+				action: 'deactivation_survey_freeform',
+				data: eventData,
+			} ),
+		} );
+		return true;
+	};
 
-    const getABTestPluginHome = () => {
-        const { NewfoldRuntime } = window;
+	const getABTestPluginHome = () => {
+		const { NewfoldRuntime } = window;
 
-        return NewfoldRuntime?.capabilities?.abTestPluginHome;
-    }
+		return NewfoldRuntime?.capabilities?.abTestPluginHome;
+	};
 
-    // Attach events listeners
-    window.addEventListener('DOMContentLoaded', () => {
-        const wpAdmin = document.querySelector('body.wp-admin');
-        wpAdmin.addEventListener('click', (e) => {
-            // Plugin deactivation listener
-            if (e.target.id === 'deactivate-' + runtimeData.pluginSlug) {
-                e.preventDefault();
-                renderDialog();
-            }
+	const showSurvey = () => {
+		const sure = document.querySelector(
+			'.nfd-deactivation-sure__content'
+		);
+		const survey = document.querySelector(
+			'.nfd-deactivation-survey__content'
+		);
+		// hide interstitial are you sure page
+		sure.classList.add( 'nfd-hidden' );
+		sure.setAttribute( 'aria-hidden', true );
+		// display survey content
+		survey.classList.remove( 'nfd-hidden' );
+		survey.removeAttribute( 'aria-hidden' );
+	};
 
-            // Remove dialog listener
-            if (e.target.hasAttribute('nfd-deactivation-survey-destroy')) {
-                destroyDialog();
-            }
+	// Attach events listeners
+	window.addEventListener( 'DOMContentLoaded', () => {
+		const wpAdmin = document.querySelector( 'body.wp-admin' );
+		wpAdmin.addEventListener( 'click', ( e ) => {
+			// Plugin deactivation listener
+			if ( e.target.id === 'deactivate-' + runtimeData.pluginSlug ) {
+				e.preventDefault();
+				renderDialog();
+			}
 
-            // Submit listener
-            if (e.target.hasAttribute('nfd-deactivation-survey-submit')) {
-                e.preventDefault();
-                submitSurvey();
-            }
+			// Remove dialog listener
+			if ( e.target.hasAttribute( 'nfd-deactivation-survey-destroy' ) ) {
+				destroyDialog();
+			}
 
-            // Skip listener
-            if (e.target.hasAttribute('nfd-deactivation-survey-skip')) {
-                e.preventDefault();
-                submitSurvey(true);
-            }
-        });
-    })
+			// Continue to survey
+			if ( e.target.hasAttribute( 'nfd-deactivation-survey-next' ) ) {
+				e.preventDefault();
+				showSurvey();
+			}
+
+			// Submit listener
+			if ( e.target.hasAttribute( 'nfd-deactivation-survey-submit' ) ) {
+				e.preventDefault();
+				submitSurvey();
+			}
+
+			// Skip listener
+			if ( e.target.hasAttribute( 'nfd-deactivation-survey-skip' ) ) {
+				e.preventDefault();
+				submitSurvey( true );
+			}
+		} );
+	} );
 }

--- a/static/js/deactivation-survey.js
+++ b/static/js/deactivation-survey.js
@@ -80,7 +80,7 @@
 					</div>
 					<div class="nfd-deactivation__body">
 						<fieldset class="nfd-deactivation-fieldset">
-							<label for="nfd-deactivation-survey__input">${ runtimeData.strings.label }</label>
+							<label for="nfd-deactivation-survey__input" class="nfd-deactivation-label">${ runtimeData.strings.label }</label>
 							<textarea id="nfd-deactivation-survey__input" class="nfd-deactivation-textarea" placeholder="${ runtimeData.strings.placeholder }"></textarea>
 						</fieldset>
 					</div>

--- a/static/js/deactivation-survey.js
+++ b/static/js/deactivation-survey.js
@@ -29,23 +29,39 @@
 
 	const getSureContent = () => {
 		const content = `
-			<div class="nfd-deactivation-sure__content">
-                <h1 id="nfd-deactivation-sure-title">${ runtimeData.strings.sureTitle }</h1>
-                <div class="nfd-deactivation-sure__content-header">
-                    <p>This plugin is currently powering features on your site. If you deactivate, these features will no longer be available.</p>
-                    <ul style="list-style: disc; list-style-position: inside;">
-						<li>Integrations with your hosting</li>
-						<li>Performance Improvements</li>
-						<li>Wonder Blocks</li>
-					</ul>
-
+			<div class="nfd-deactivation-sure nfd-deactivation__content">
+				<div class="nfd-deactivation__header">
+					<h1 class="nfd-deactivation__content-title">${ runtimeData.strings.sureTitle }</h1>
+                    <p class="nfd-deactivation__content-subtitle">This plugin is powers important features on your site. These will no longer be available if you deactivate the plugin.</p>
+				</div>
+				<div class="nfd-deactivation__body">
+                    <div class="nfd-deactivation__cards">
+						<div class="nfd-deactivation__card">Hosting integrations</div>
+						<div class="nfd-deactivation__card">Performance Improvements</div>
+						<div class="nfd-deactivation__card">Staging Site Support</div>
+						<div class="nfd-deactivation__card">Wonder Blocks</div>
+						<div class="nfd-deactivation__card">Integrated AI Help Center</div>
+					</div>
+				</div>
+				<div class="nfd-deactivation__footer"><div class="nfd-deactivation__footer-content">
 					<div class="nfd-deactivation-survey__content-actions">
-						<div>
-							<button type="button" nfd-deactivation-survey-next class="nfd-button nfd-button-seconday nfd-deactivation-survey-action" aria-label="${ runtimeData.strings.submitAriaLabel }">Continue</button>
-							<button type="button" class="nfd-button nfd-button-primary nfd-deactivation-survey-action" nfd-deactivation-survey-destroy aria-label="${ runtimeData.strings.cancelAriaLabel }">${ runtimeData.strings.cancel }</button>
+						<div class="nfd-deactivation__helptext" "style="text-align:left">
+							<p><b>Need Help?</b> Learn more about <a href="#" target="_blank" nfd-deactivation-survey-destroy>the features of this plugin</a>, check the <a href="#">help center</a>, or <a href="#">contact support</a>.</p>
+						</div>
+						<div class="nfd-deactivation-survey__content-buttons">
+							<button type="button" nfd-deactivation-survey-destroy
+								class="button button-primary" 
+								aria-label="${ runtimeData.strings.cancelAriaLabel }">
+								${ runtimeData.strings.cancel }
+							</button>
+							<button type="button" nfd-deactivation-survey-next 
+								class="button button-seconday" 
+								aria-label="${ runtimeData.strings.submitAriaLabel }">
+								Continue
+							</button>
 						</div>
 					</div>
-                </div>
+                </div></div>
             </div>
 		`;
 		return content;
@@ -53,15 +69,31 @@
 
 	const getSurveyContent = () => {
 		const content = `
-			<div class="nfd-deactivation-survey__content nfd-hidden" aria-hidden="true">
-                <h1 id="nfd-deactivation-survey-title" class="nfd-hidden" aria-hidden="true">${
-					runtimeData.strings.surveyTitle
-				}</h1>
-                <div class="nfd-deactivation-survey__content-header">
-                    <h3>${ runtimeData.strings.dialogTitle }</h3>
-                    <p>${ runtimeData.strings.dialogDesc }</p>
-                </div>
-                ${ getSurveyFormHTML() }
+			<div class="nfd-deactivation-survey nfd-deactivation__content nfd-hidden" aria-hidden="true">
+				<form class="nfd-deactivation-form" aria-label="${ runtimeData.strings.formAriaLabel }">
+					<div class="nfd-deactivation__header">
+						<h1 id="nfd-deactivation-survey-title" class="nfd-hidden" aria-hidden="true">
+							${ runtimeData.strings.surveyTitle }
+						</h1>
+						<h3 class="nfd-deactivation__content-subtitle">${ runtimeData.strings.dialogTitle }</h3>
+						<p class="nfd-deactivation__content-subtitle">${ runtimeData.strings.dialogDesc }</p>
+					</div>
+					<div class="nfd-deactivation__body">
+						<fieldset class="nfd-deactivation-fieldset">
+							<label for="nfd-deactivation-survey__input">${ runtimeData.strings.label }</label>
+							<textarea id="nfd-deactivation-survey__input" class="nfd-deactivation-textarea" placeholder="${ runtimeData.strings.placeholder }"></textarea>
+						</fieldset>
+					</div>
+					<div class="nfd-deactivation__footer"><div class="nfd-deactivation__footer-content nfd-deactivation-survey__content-actions">
+						<div>
+							<button type="button" class="button button-secondary" nfd-deactivation-survey-destroy aria-label="${ runtimeData.strings.cancelAriaLabel }">${ runtimeData.strings.cancel }</button>
+						</div>
+						<div class="nfd-deactivation-survey__content-actions">
+							<button type="button" class="nfd-deactivation-survey-action" nfd-deactivation-survey-skip aria-label="${ runtimeData.strings.skipAriaLabel }">${ runtimeData.strings.skip }</button>
+							<input type="submit" value="${ runtimeData.strings.submit }" nfd-deactivation-survey-submit class="button button-primary" aria-label="${ runtimeData.strings.submitAriaLabel }"/>
+						</div>
+					</div></div>
+				</form>
                 <span class="nfd-deactivation-survey_loading nfd-hidden"></span>
             </div>
 		`;
@@ -71,32 +103,11 @@
 	const getDialogHTML = () => {
 		const content = `
 			<div class="nfd-deactivation-survey__overlay" nfd-deactivation-survey-destroy></div>
-			<div class="nfd-deactivation-survey__container" role="document">
+			<div class="nfd-deactivation-survey__container" role="document" data-step="1">
 				${ getSureContent() }
 				${ getSurveyContent() }
 			</div>
 			<div class="nfd-deactivation-survey__disabled nfd-hidden"></div>
-        `;
-		return content;
-	};
-
-	const getSurveyFormHTML = () => {
-		const content = `
-			<form aria-label="${ runtimeData.strings.formAriaLabel }">
-				<fieldset>
-					<label for="nfd-deactivation-survey__input">${ runtimeData.strings.label }</label>
-					<textarea id="nfd-deactivation-survey__input" placeholder="${ runtimeData.strings.placeholder }"></textarea>
-				</fieldset>
-				<div class="nfd-deactivation-survey__content-actions">
-					<div>
-						<input type="submit" value="${ runtimeData.strings.submit }" nfd-deactivation-survey-submit class="button button-primary" aria-label="${ runtimeData.strings.submitAriaLabel }"/>
-						<button type="button" class="nfd-deactivation-survey-action" nfd-deactivation-survey-destroy aria-label="${ runtimeData.strings.cancelAriaLabel }">${ runtimeData.strings.cancel }</button>
-					</div>
-					<div>
-						<button type="button" class="nfd-deactivation-survey-action" nfd-deactivation-survey-skip aria-label="${ runtimeData.strings.skipAriaLabel }">${ runtimeData.strings.skip }</button>
-					</div>
-				</div>
-			</form>
         `;
 		return content;
 	};
@@ -208,12 +219,14 @@
 	};
 
 	const showSurvey = () => {
-		const sure = document.querySelector(
-			'.nfd-deactivation-sure__content'
+		const container = document.querySelector(
+			'.nfd-deactivation-survey__container'
 		);
-		const survey = document.querySelector(
-			'.nfd-deactivation-survey__content'
-		);
+		const sure = document.querySelector( '.nfd-deactivation-sure' );
+		const survey = document.querySelector( '.nfd-deactivation-survey' );
+		// update container with data setp 2
+		container.setAttribute( 'data-step', '2' );
+
 		// hide interstitial are you sure page
 		sure.classList.add( 'nfd-hidden' );
 		sure.setAttribute( 'aria-hidden', true );

--- a/static/js/deactivation-survey.js
+++ b/static/js/deactivation-survey.js
@@ -27,26 +27,34 @@
 		deactivationSurveyDialog.show();
 	};
 
+	const getSureCards = () => {
+		return runtimeData.strings.sureCards
+			.map( ( card ) => {
+				return `<div class="nfd-deactivation__card">${ card }</div>`;
+			} )
+			.join( '' );
+	};
+
 	const getSureContent = () => {
 		const content = `
 			<div class="nfd-deactivation-sure nfd-deactivation__content">
 				<div class="nfd-deactivation__header">
-					<h1 class="nfd-deactivation__content-title">${ runtimeData.strings.sureTitle }</h1>
-                    <p class="nfd-deactivation__content-subtitle">This plugin is powers important features on your site. These will no longer be available if you deactivate the plugin.</p>
+					<h1 class="nfd-deactivation__content-title">${
+						runtimeData.strings.sureTitle
+					}</h1>
+                    <p class="nfd-deactivation__content-subtitle">${
+						runtimeData.strings.sureDesc
+					}</p>
 				</div>
 				<div class="nfd-deactivation__body">
                     <div class="nfd-deactivation__cards">
-						<div class="nfd-deactivation__card">Hosting integrations</div>
-						<div class="nfd-deactivation__card">Performance Improvements</div>
-						<div class="nfd-deactivation__card">Staging Site Support</div>
-						<div class="nfd-deactivation__card">Wonder Blocks</div>
-						<div class="nfd-deactivation__card">Integrated AI Help Center</div>
+						${ getSureCards() }
 					</div>
 				</div>
 				<div class="nfd-deactivation__footer"><div class="nfd-deactivation__footer-content">
 					<div class="nfd-deactivation-survey__content-actions">
 						<div class="nfd-deactivation__helptext" "style="text-align:left">
-							<p><b>Need Help?</b> Learn more about <a href="#" target="_blank" nfd-deactivation-survey-destroy>the features of this plugin</a>, check the <a href="#">help center</a>, or <a href="#">contact support</a>.</p>
+							<p>${ runtimeData.strings.sureHelp }</p>
 						</div>
 						<div class="nfd-deactivation-survey__content-buttons">
 							<button type="button" nfd-deactivation-survey-destroy
@@ -56,8 +64,8 @@
 							</button>
 							<button type="button" nfd-deactivation-survey-next 
 								class="button button-seconday" 
-								aria-label="${ runtimeData.strings.submitAriaLabel }">
-								Continue
+								aria-label="${ runtimeData.strings.continueAriaLabel }">
+								${ runtimeData.strings.continue }
 							</button>
 						</div>
 					</div>
@@ -73,10 +81,10 @@
 				<form class="nfd-deactivation-form" aria-label="${ runtimeData.strings.formAriaLabel }">
 					<div class="nfd-deactivation__header">
 						<h1 id="nfd-deactivation-survey-title" class="nfd-hidden" aria-hidden="true">
-							${ runtimeData.strings.surveyTitle }
+							${ runtimeData.strings.surveyAriaTitle }
 						</h1>
-						<h3 class="nfd-deactivation__content-subtitle">${ runtimeData.strings.dialogTitle }</h3>
-						<p class="nfd-deactivation__content-subtitle">${ runtimeData.strings.dialogDesc }</p>
+						<h2 class="nfd-deactivation__content-title">${ runtimeData.strings.surveyTitle }</h2>
+						<p class="nfd-deactivation__content-subtitle">${ runtimeData.strings.surveyDesc }</p>
 					</div>
 					<div class="nfd-deactivation__body">
 						<fieldset class="nfd-deactivation-fieldset">

--- a/static/js/deactivation-survey.js
+++ b/static/js/deactivation-survey.js
@@ -30,7 +30,14 @@
 	const getSureCards = () => {
 		return runtimeData.strings.sureCards
 			.map( ( card ) => {
-				return `<div class="nfd-deactivation__card">${ card }</div>`;
+				if ( card.condition !== true && ! eval( card.condition ) ) {
+					return '';
+				}
+
+				return `<div class="nfd-deactivation__card">
+					<span class="nfd-deactivation__card-title">${ card.title }</span>
+					<span class="nfd-deactivation__card-desc">${ card.desc }</span>
+				</div>`;
 			} )
 			.join( '' );
 	};


### PR DESCRIPTION
## Proposed changes

This adds an "Are you sure?" interstitial before showing the deactivation survey.

I added styles - inspired by similar interstitials and updated the survey styles for consistency. 

This is still waiting on better/final copy/content from @chrisdavidmiles but the code is set up now, I'll add some screenshots for preview.

![Screenshot 2024-03-08 at 4 34 45 PM](https://github.com/newfold-labs/wp-module-deactivation/assets/698049/f83f0631-6606-48e2-a2f4-23e128cbc9a5)
![Screenshot 2024-03-08 at 4 38 25 PM](https://github.com/newfold-labs/wp-module-deactivation/assets/698049/672cfd57-83e9-4393-88db-66e122517ff7)


TODO:
- Still needs a hiive event added for advancing to the survey.
- Add content strings to localized strings for translation and plugin overrides.
- Update tests to reflect the new flow.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
