### PR TITLE
replace plugin name with dynamic value from container

### DIFF
--- a/includes/DeactivationSurvey.php
+++ b/includes/DeactivationSurvey.php
@@ -24,7 +24,7 @@ class DeactivationSurvey {
 		$defaults = array(
 			'surveyAriaTitle'   => __( 'Plugin Deactivation Survey', 'wp-module-deactivation' ),
 			'surveyTitle'       => sprintf( 
-				__( 'Thank you for using the %s plugin!', 'wp-module-deactivation' ), 
+				__( 'Thank you for using the %s plugin!', 'wp-module-deactivation' ),
 				ucwords( container()->plugin()->id )
 			),
 			'surveyDesc'        => __( 'Please take a moment to let us know why you\'re deactivating this plugin.', 'wp-module-deactivation' ),
@@ -40,7 +40,10 @@ class DeactivationSurvey {
 			'continue'          => __( 'Continue', 'wp-module-deactivation' ),
 			'continueAriaLabel' => __( 'Continue Deactivation', 'wp-module-deactivation' ),
 			'sureTitle'         => __( 'Are you sure you want to deactivate?', 'wp-module-deactivation' ),
-			'sureDesc'          => __( 'If the Bluehost plugin is deactivated, these features will no longer work:', 'wp-module-deactivation' ),
+			'sureDesc'          => sprintf( 
+				__( 'If the %s plugin is deactivated, these features will no longer work:', 'wp-module-deactivation' ),
+				ucwords( container()->plugin()->id )
+			),
 			'sureCards'         => array(
 				array(
 					'title' => sprintf( 


### PR DESCRIPTION
## Proposed changes

With the final round of copy edits a hard coded bluehost string slipped through. This uses the same sprintf method to replace the plugin name with the id from the container.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
