### PR TITLE
fixes a php notice in 8.2

### DIFF
--- a/includes/DeactivationSurvey.php
+++ b/includes/DeactivationSurvey.php
@@ -15,11 +15,14 @@ use function NewfoldLabs\WP\ModuleLoader\container;
  */
 class DeactivationSurvey {
 
+	// public $container;
+	public $strings;
+
 	/**
 	 * DeactivationSurvey constructor.
 	 */
 	public function __construct() {
-		// $this->container = $container;
+		// $this->container = container();
 
 		$defaults = array(
 			'surveyAriaTitle'   => __( 'Plugin Deactivation Survey', 'wp-module-deactivation' ),
@@ -80,8 +83,8 @@ class DeactivationSurvey {
 
 		// Merge defaults with container values from plugin
 		// $this->strings = wp_parse_args(
-		// 	$container->has( 'deactivation' ) ? 
-		// 	$container['deactivation'] : 
+		// 	$this->container->has( 'deactivation' ) ? 
+		// 	$this->container['deactivation'] : 
 		// 	array(), 
 		// 	$defaults
 		// );


### PR DESCRIPTION
There is a notice when a brand plugin as the builder plugin are both active. This change simply defines the property so it is not dynamically defined.

Deprecated: Creation of dynamic property NewfoldLabs\WP\Module\Deactivation\DeactivationSurvey::$strings is deprecated

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
