### PR TITLE
require the newfold-features script and only display enabled features

### DIFF
--- a/includes/DeactivationSurvey.php
+++ b/includes/DeactivationSurvey.php
@@ -54,7 +54,7 @@ class DeactivationSurvey {
 						ucwords( container()->plugin()->id )
 					),
 					'desc'  => __( 'Automatically clears the server page cache when your site updates', 'wp-module-deactivation' ),
-					'condition' => true,
+					'condition' => 'window.NewfoldFeatures.features.performance',
 				),
 				array(
 					'title' => sprintf(
@@ -62,7 +62,7 @@ class DeactivationSurvey {
 						ucwords( container()->plugin()->id )
 					),
 					'desc'  => __( 'Create a staging copy of your site to safely test changes', 'wp-module-deactivation' ),
-					'condition' => true,
+					'condition' => 'window.NewfoldFeatures.features.staging',
 				),
 				array(
 					'title' => __( 'WooCommerce Tools', 'wp-module-deactivation' ),
@@ -72,7 +72,7 @@ class DeactivationSurvey {
 				array(
 					'title' => __( 'Wonder Blocks & Patterns Library', 'wp-module-deactivation' ),
 					'desc'  => __( 'Dozens of beautiful block templates and patterns', 'wp-module-deactivation' ),
-					'condition' => true,
+					'condition' => 'window.NewfoldFeatures.features.patterns',
 				),
 			),
 			'sureHelp'     => sprintf( 
@@ -112,7 +112,7 @@ class DeactivationSurvey {
 		wp_enqueue_script(
 			'nfd-deactivation-survey',
 			$assets_dir . 'js/deactivation-survey.js',
-			array( 'nfd-deactivation-a11y-dialog' ),
+			array( 'newfold-features', 'nfd-deactivation-a11y-dialog' ),
 			container()->plugin()->version,
 			true
 		);


### PR DESCRIPTION
## Proposed changes

This updates the "Are you sure" cards to display only if that feature is enabled.

If the site doesn't have a feature enabled for example, we shouldn't show that as a plugin feature to consider when deactivating (we already do this with the WooCommerce Tools card).

We should also add some more cards in case all the current ones do not display.

See: PRESS0-1417

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
