### PR TITLE
bug/Deactivate Screen Unusable on Mobile

### DIFF
--- a/static/css/deactivation-survey.css
+++ b/static/css/deactivation-survey.css
@@ -285,6 +285,12 @@
     }
 }
 
+@media screen and (max-width: 600px) {
+    .nfd-deactivation-survey__container {
+      overflow: scroll;
+    }
+  }
+
 /* animations */
 @keyframes nfd-submitting {
     0% {


### PR DESCRIPTION
issue fixed  is just that you can't get to the buttons to cancel or deactivate if your screen isn't big enough to see the whole deactivate screen at once (so phones, maybe some tablets).

story : https://jira.newfold.com/browse/PRESS0-1530 