### PR TITLE
Removed event for sending Deactivation duration

### DIFF
--- a/static/js/deactivation-survey.js
+++ b/static/js/deactivation-survey.js
@@ -194,9 +194,6 @@
 		// Send event
 		return await sendSurveyEvent( skipped )
 			.then( () => {
-				sendDurationEvent();
-			} )
-			.then( () => {
 				deactivatePlugin();
 			} );
 	};
@@ -221,23 +218,6 @@
 			'deactivation_survey_freeform',
 			'survey_input',
 			surveyInput
-		);
-	};
-
-	/**
-	 * Helper to send duration event data
-	 *
-	 * @return {Promise} via SendEvent
-	 */
-	const sendDurationEvent = async () => {
-		const deactivationDuration = document.getElementById(
-			'deactivation-duration'
-		).value;
-
-		return sendEvent(
-			'deactivation_duration_select',
-			'deactivation_duration',
-			deactivationDuration
 		);
 	};
 


### PR DESCRIPTION
Removed event for sending Deactivation duration. 

The deactivation duration dropdown has been removed, but the code that sends an event to Hiive has not been removed.
