### PR TITLE
Add initial docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,4 +38,4 @@ composer run i18n
 
 ## Keeping documentation current
 
-When you change code, features, or workflows, update the docs. When cutting a release, update **docs/changelog.md**.
+When you change code, features, or workflows, update the docs. Keep **docs/index.md** current: when you add, remove, or rename doc files, update the table of contents (and quick links if present). When cutting a release, update **docs/changelog.md**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Agent guidance – wp-module-deactivation
+
+This file gives AI agents a quick orientation to the repo. For full detail, see the **docs/** directory.
+
+## What this project is
+
+- **wp-module-deactivation** – Handles WordPress brand plugin and module deactivation. Hooks into `newfold_container_set`, registers the plugin’s deactivation hook (to disable coming soon, clear transients, etc.), and loads a deactivation survey on the plugins screen. Requires wp-module-data. Maintained by Newfold Labs.
+
+- **Stack:** PHP 7.3+. Depends on `newfold-labs/wp-module-data`.
+
+- **Architecture:** On `newfold_container_set`, defines `NFD_DEACTIVATION_DIR` and instantiates `Deactivation( $container )`, which registers `register_deactivation_hook` and adds the DeactivationSurvey on `admin_head-plugins.php`.
+
+## Key paths
+
+| Purpose | Location |
+|---------|----------|
+| Bootstrap | `bootstrap.php` |
+| Deactivation logic | `includes/Deactivation.php` – on_deactivate, survey |
+| Survey | `includes/DeactivationSurvey.php` (and related) |
+| Tests | `tests/` |
+
+## Essential commands
+
+```bash
+composer install
+composer run lint
+composer run fix
+composer run test
+composer run i18n
+```
+
+## Documentation
+
+- **Full documentation** is in **docs/**. Start with **docs/index.md**.
+- **CLAUDE.md** is a symlink to this file (AGENTS.md).
+
+---
+
+## Keeping documentation current
+
+When you change code, features, or workflows, update the docs. When cutting a release, update **docs/changelog.md**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-deactivation
+title: Dependencies
+description: Composer and npm dependencies.
+updated: 2025-03-18
+---
+
 # Dependencies
 
 ## Runtime

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,15 @@
+# Dependencies
+
+## Runtime
+
+| Package | Purpose |
+|---------|---------|
+| **newfold-labs/wp-module-data** | Used for context or data-related cleanup on deactivation. Required so the container and plugin state are available. |
+
+## Dev
+
+- **newfold-labs/wp-php-standards** – PHPCS.
+- **johnpbloch/wordpress** – WordPress core for tests.
+- **lucatume/wp-browser** – Codeception wpunit.
+- **phpunit/phpcov** – Coverage.
+- **wp-cli/i18n-command** – i18n pot/po/mo/json.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-deactivation
+title: Development
+description: Lint, test, and workflow.
+updated: 2025-03-18
+---
+
 # Development
 
 ## Linting

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,19 @@
+# Development
+
+## Linting
+
+- **PHP:** `composer run lint`, `composer run fix`. Uses `phpcs.xml` and `newfold-labs/wp-php-standards`.
+
+## Testing
+
+- **Codeception wpunit:** `composer run test`, `composer run test-coverage`. Open `tests/_output/html/index.html` for coverage.
+
+## i18n
+
+- Text domain: **wp-module-deactivation**. Use `composer run i18n-pot`, `composer run i18n`, etc. Language files in `languages/`.
+
+## Workflow
+
+1. Make changes in `includes/` or `bootstrap.php`.
+2. Run `composer run lint` and `composer run test` before committing.
+3. When changing deactivation behavior or survey, update [integration.md](integration.md) and [overview.md](overview.md). When cutting a release, update **docs/changelog.md**.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-deactivation
+title: Getting started
+description: Prerequisites, install, and run.
+updated: 2025-03-18
+---
+
 # Getting started
 
 ## Prerequisites

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,36 @@
+# Getting started
+
+## Prerequisites
+
+- **PHP** 7.3+.
+- **Composer.** The module requires `newfold-labs/wp-module-data`.
+
+## Install
+
+```bash
+composer install
+```
+
+## Run tests
+
+```bash
+composer run test
+composer run test-coverage
+```
+
+## Lint and i18n
+
+```bash
+composer run lint
+composer run fix
+composer run i18n
+```
+
+Text domain: **wp-module-deactivation**. See [development.md](development.md).
+
+## Using in a host plugin
+
+1. Depend on `newfold-labs/wp-module-deactivation` (and ensure wp-module-data is present).
+2. Load the module’s bootstrap (Composer autoload files). When the host sets the container, this module registers the deactivation hook and survey. No further configuration required.
+
+See [integration.md](integration.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,20 @@
+# wp-module-deactivation – Documentation index
+
+Documentation for wp-module-deactivation, for **humans** and **AI agents**. Start here.
+
+## Table of contents
+
+| Document | Description |
+|----------|-------------|
+| [overview.md](overview.md) | What the module does and who maintains it. |
+| [getting-started.md](getting-started.md) | Prerequisites, install, and tests. |
+| [integration.md](integration.md) | How the module hooks and what runs on deactivation. |
+| [development.md](development.md) | Lint, test, i18n, and workflow. |
+| [dependencies.md](dependencies.md) | Composer dependencies. |
+
+## Quick links
+
+- **New to the repo:** [overview.md](overview.md) then [getting-started.md](getting-started.md).
+- **Integrating in a host plugin:** [integration.md](integration.md).
+
+Root **AGENTS.md** gives a short agent summary and points here.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-deactivation
+title: Documentation index
+description: Table of contents and quick links.
+updated: 2025-03-18
+---
+
 # wp-module-deactivation – Documentation index
 
 Documentation for wp-module-deactivation, for **humans** and **AI agents**. Start here.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-deactivation
+title: Integration
+description: How the module registers and integrates.
+updated: 2025-03-18
+---
+
 # Integration
 
 ## How the module runs

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,24 @@
+# Integration
+
+## How the module runs
+
+The module hooks into **`newfold_container_set`**. In the callback it defines `NFD_DEACTIVATION_DIR` (this package root) and instantiates `Deactivation( $container )`.
+
+**Deactivation** class:
+
+- Registers `register_deactivation_hook( $container->plugin()->file, [ $this, 'on_deactivate' ] )`.
+- On `admin_head-plugins.php`, instantiates `DeactivationSurvey()` so the survey UI is available on the Plugins screen.
+
+## On deactivate
+
+`on_deactivate()` runs when the brand plugin is deactivated. It typically:
+
+- Disables coming soon mode (via the coming soon module or option).
+- Clears transients (e.g. `newfold_marketplace`, `newfold_notifications`, and others as defined in the class).
+- May flush rewrite rules or perform other cleanup.
+
+See `includes/Deactivation.php` for the full list.
+
+## Dependencies
+
+The module requires **wp-module-data**. Ensure the data module is loaded before or with the deactivation module so the container and any data cleanup are available.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,14 @@
+# Overview
+
+## What the module does
+
+**wp-module-deactivation** handles deactivation of Newfold WordPress brand plugins and related cleanup. When the container is set, it:
+
+- **Registers the plugin deactivation hook** – On deactivation it disables coming soon mode, clears transients (e.g. newfold_marketplace, newfold_notifications), and performs other cleanup.
+- **Deactivation survey** – On the plugins screen (`admin_head-plugins.php`), it loads a deactivation survey so users can optionally provide feedback when deactivating the brand plugin.
+
+The module depends on **wp-module-data** (e.g. for context or data cleanup). It does not register as a toggleable loader module; it runs when the container is set.
+
+## Who maintains it
+
+- **Newfold Labs** (Newfold Digital). Distributed via Newfold Satis.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-deactivation
+title: Overview
+description: What the module does and who maintains it.
+updated: 2025-03-18
+---
+
 # Overview
 
 ## What the module does


### PR DESCRIPTION
Adds AGENTS.md, CLAUDE.md (symlink to AGENTS.md), and docs/ per the Newfold modules documentation rollout: overview, getting-started, integration, development, and dependencies where applicable.

Made with [Cursor](https://cursor.com)