### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -19,10 +19,10 @@ permissions: {}
 jobs:
   translate:
     name: 'Check and update translations'
-    uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     permissions:
       contents: write      # Required by reusable-translations jobs that persist credentials and push the auto-translate branch.
       pull-requests: write # Required by reusable-translations for gh PR operations (list/update/create) throughout the callee workflow.
+    uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     timeout-minutes: 45
     with:
       text_domain: 'wp-module-deactivation'

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write      # Required by reusable-translations jobs that persist credentials and push the auto-translate branch.
       pull-requests: write # Required by reusable-translations for gh PR operations (list/update/create) throughout the callee workflow.
+    timeout-minutes: 45
     with:
       text_domain: 'wp-module-deactivation'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,15 +12,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
+    permissions:
+      contents: write      # Required by reusable-translations jobs that persist credentials and push the auto-translate branch.
+      pull-requests: write # Required by reusable-translations for gh PR operations (list/update/create) throughout the callee workflow.
     with:
       text_domain: 'wp-module-deactivation'
     secrets:

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -18,6 +18,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions: {}
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
@@ -34,6 +35,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required so the callee workflow token can checkout the private plugin/module repositories.
+    timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -32,9 +32,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Cypress
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required so the callee workflow token can checkout the private plugin/module repositories.
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -10,10 +10,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -27,6 +32,8 @@ jobs:
     name: Bluehost Build and Test Cypress
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required so the callee workflow token can checkout the private plugin/module repositories.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -30,10 +32,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    permissions:
+      contents: write      # Matches reusable-codecoverage pushes to gh-pages and checkouts needing write-capable Git auth.
+      pull-requests: write # Matches reusable-codecoverage posting PR coverage comments via add-pr-comment.
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -20,6 +20,7 @@ permissions: {}
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions: {}
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
@@ -36,6 +37,7 @@ jobs:
     permissions:
       contents: write      # Matches reusable-codecoverage pushes to gh-pages and checkouts needing write-capable Git auth.
       pull-requests: write # Matches reusable-codecoverage posting PR coverage comments via add-pr-comment.
+    timeout-minutes: 120
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -33,10 +33,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     permissions:
       contents: write      # Matches reusable-codecoverage pushes to gh-pages and checkouts needing write-capable Git auth.
       pull-requests: write # Matches reusable-codecoverage posting PR coverage comments via add-pr-comment.
+    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     timeout-minutes: 120
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -17,6 +17,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     permissions:
       contents: read # Matches the reusable workflow checkout; Crowdin/GitHub mutations use PAT from NEWFOLD_ACCESS_TOKEN inside the callee.
+    timeout-minutes: 30
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -14,9 +14,9 @@ permissions: {}
 
 jobs:
   call-crowdin-workflow:
-    uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     permissions:
       contents: read # Matches the reusable workflow checkout; Crowdin/GitHub mutations use PAT from NEWFOLD_ACCESS_TOKEN inside the callee.
+    uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     timeout-minutes: 30
     with:
       base_branch: ${{ inputs.base_branch }}

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -8,15 +8,18 @@ on:
         required: false
         default: 'main'
 
-permissions:
-  contents: write
-  pull-requests: write
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   call-crowdin-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
+    permissions:
+      contents: read # Matches the reusable workflow checkout; Crowdin/GitHub mutations use PAT from NEWFOLD_ACCESS_TOKEN inside the callee.
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:
       CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+      NEWFOLD_ACCESS_TOKEN: ${{ secrets.NEWFOLD_ACCESS_TOKEN }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -9,9 +9,9 @@ permissions: {}
 
 jobs:
   call-crowdin-upload-workflow:
-    uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     permissions:
       contents: read # Matches the reusable workflow checkout and Crowdin action use of secrets.GITHUB_TOKEN for repository read access only.
+    uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     timeout-minutes: 20
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -12,6 +12,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     permissions:
       contents: read # Matches the reusable workflow checkout and Crowdin action use of secrets.GITHUB_TOKEN for repository read access only.
+    timeout-minutes: 20
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -3,9 +3,15 @@ name: Crowdin Upload Action
 on:
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   call-crowdin-upload-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
+    permissions:
+      contents: read # Matches the reusable workflow checkout and Crowdin action use of secrets.GITHUB_TOKEN for repository read access only.
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read # Required for actions/checkout to clone the private repository.
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required for actions/checkout to clone the private repository.
     steps:
 
       - name: Checkout

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -13,6 +13,7 @@ jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions: {}
     steps:
 

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
 
     - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 7 (`auto-translate.yml`, `brand-plugin-test-playwright.yml`, `codecoverage-main.yml`, `i18n-crowdin-download.yml`, `i18n-crowdin-upload.yml`, `lint.yml`, `satis-update.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `9300c78` |
| Timeouts commit | `3494e67` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-update.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test-playwright.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-upload.yml` |
| Workflows that had a non-empty or non-conforming top-level `permissions` block replaced with the mandated comment + `permissions: {}` (applied in this run): | `codecoverage-main.yml` (previously `contents: read` at workflow level) |
| Workflows that had a non-empty or non-conforming top-level `permissions` block replaced with the mandated comment + `permissions: {}` (applied in this run): | `i18n-crowdin-download.yml` (previously `contents: write` / `pull-requests: write` at workflow level) |
| Workflows that already had `permissions: {}` but were missing the mandated comment prelude (added in this run): | `auto-translate.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| satis-update.yml | 1 job was missing a scoped `permissions:` directive | webhook | `permissions: {}` [3] |
| lint.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read` [3] |
| codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| brand-plugin-test-playwright.yml | 2 jobs were missing a scoped `permissions:` directive | setup | `permissions: {}` [3] |
| brand-plugin-test-playwright.yml | 2 jobs were missing a scoped `permissions:` directive | bluehost | `contents: read` [3] |
| i18n-crowdin-upload.yml | 1 job was missing a scoped `permissions:` directive | call-crowdin-upload-workflow | `contents: read` [3] |
| i18n-crowdin-download.yml | 1 job was missing a scoped `permissions:` directive | call-crowdin-workflow | `contents: read` [3] |
| auto-translate.yml | 0 jobs were missing a `permissions:` directive (the `translate` job already declared `contents: write` / `pull-requests: write`; this run added per-permission inline comments only) | — | — |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `codecoverage-main.yml` :: workflow-level: BEFORE `permissions: contents: read` -> AFTER mandated `permissions: {}` with grants only on the reusable-call job -- The workflow-level read grant was unnecessary for the default-deny pattern and overlapped confusingly with the reusable workflow’s much broader token needs that are correctly scoped on the call job -- [3] |
| 2 | `i18n-crowdin-download.yml` :: `call-crowdin-workflow`: BEFORE workflow-level `contents: write` + `pull-requests: write` (effectively granting broad write scopes to the whole workflow) -> AFTER `contents: read` on the call job -- Matches the current `newfold-labs/workflows` Crowdin download reusable workflow, which scopes the workflow `GITHUB_TOKEN` to checkout read and uses `NEWFOLD_ACCESS_TOKEN` (PAT) for branch/PR operations inside the action -- [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| satis-update.yml | webhook | `15` | Webhook-style repository dispatch should finish quickly; a short cap limits wasted minutes if a step hangs. |
| lint.yml | phpcs | `30` | Composer install plus PHPCS on changed PHP files is usually well under this; 30 minutes is a standard CI guardrail. |
| codecoverage-main.yml | get-repo-name | `5` | Name extraction is instantaneous; a small timeout only guards runaway runners. |
| codecoverage-main.yml | codecoverage | `120` | The reusable codecoverage workflow runs a MySQL service and a large PHP version matrix with PHPUnit/Codeception; allow enough time for the slowest matrix leg plus gh-pages push retries. |
| brand-plugin-test-playwright.yml | setup | `10` | Branch name extraction only; minimal ceiling. |
| brand-plugin-test-playwright.yml | bluehost | `60` | Playwright + `wp-env` + dependency installs can be slow; an hour ceiling reduces risk of an unbounded run without being excessive for PR CI. |
| i18n-crowdin-upload.yml | call-crowdin-upload-workflow | `20` | Crowdin upload is typically short; matches the same order of magnitude as the reusable workflow’s internal timeout budget. |
| i18n-crowdin-download.yml | call-crowdin-workflow | `30` | Allows Crowdin sync + checkout + Git operations with headroom versus a bare default. |
| auto-translate.yml | translate | `45` | Calls a multi-job reusable translation workflow; moderate cap avoids a stuck run absorbing large minute pools. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | `i18n-crowdin-download.yml` now forwards `secrets.NEWFOLD_ACCESS_TOKEN` into `NEWFOLD_ACCESS_TOKEN`, matching the callee contract in `newfold-labs/workflows` (without this mapping, reusable `workflow_call` cannot receive that secret even if it exists only as a repository/org secret). |
| 2 | Several workflows pin reusable workflows at `@main` in `newfold-labs/workflows`; permission needs were verified against the current copies in the local sibling checkout at `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/workflows`—if upstream changes diverge materially, rerun this review after updating pins or confirming upstream behavior (`peter-evans/repository-dispatch`, Crowdin/GitHub Actions, reusable codecoverage/playwright/translations workflows). |


