### PR TITLE
Handle survey event send failures without blocking deactivation

### DIFF
--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -24,11 +24,23 @@ jobs:
         id: extract_branch
 
   bluehost:
-    name: Bluehost Build and Test Cypress
+    name: Bluehost Build and Test Playwright
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'newfold-labs/wp-plugin-bluehost'
+    secrets: inherit
+
+  bluehost:
+    name: Bluehost DEV Build and Test Playwright
+    needs: setup
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    with:
+      module-repo: ${{ github.repository }}
+      module-branch: ${{ needs.setup.outputs.branch }}
+      plugin-repo: 'newfold-labs/wp-plugin-bluehost'
+      plugin-branch: 'develop'
+      artifact-name: 'wp-plugin-bluehost-develop'
     secrets: inherit

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     name: Setup
@@ -33,7 +36,7 @@ jobs:
       plugin-repo: 'newfold-labs/wp-plugin-bluehost'
     secrets: inherit
 
-  bluehost:
+  bluehost-dev:
     name: Bluehost DEV Build and Test Playwright
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main

--- a/static/js/deactivation-survey.js
+++ b/static/js/deactivation-survey.js
@@ -227,13 +227,15 @@
 		} );
 	};
 
-	const submitSurvey = ( skipped = false ) => {
+	const submitSurvey = async ( skipped = false ) => {
 		isSubmitting();
 
 		// Fire-and-forget: the analytics event is best-effort and must never
 		// delay or block the actual deactivation redirect, whether it
-		// succeeds, fails, or is still in flight.
-		sendSurveyEvent( skipped ).catch( ( error ) => {
+		// succeeds, fails, or is still in flight. `submitSurvey` stays async
+		// (resolving immediately) to preserve its existing Promise-returning
+		// signature for any caller relying on it.
+		void sendSurveyEvent( skipped ).catch( ( error ) => {
 			console.error( 'Error: Failed to send deactivation survey event.', error );
 		} );
 
@@ -296,6 +298,8 @@
 				action,
 				data: eventData,
 			} ),
+			// Let the request outlive the page navigation triggered by deactivatePlugin().
+			keepalive: true,
 		} );
 	};
 

--- a/static/js/deactivation-survey.js
+++ b/static/js/deactivation-survey.js
@@ -227,6 +227,16 @@
 		} );
 	};
 
+	/**
+	 * Skip or submit the survey and deactivate the plugin.
+	 *
+	 * The returned promise resolves immediately once deactivation is triggered — it does
+	 * not wait for the analytics event to complete, so it cannot be used to detect whether
+	 * that event succeeded.
+	 *
+	 * @param {boolean} skipped
+	 * @return {Promise<void>}
+	 */
 	const submitSurvey = async ( skipped = false ) => {
 		isSubmitting();
 

--- a/static/js/deactivation-survey.js
+++ b/static/js/deactivation-survey.js
@@ -227,19 +227,17 @@
 		} );
 	};
 
-	const submitSurvey = async ( skipped = false ) => {
+	const submitSurvey = ( skipped = false ) => {
 		isSubmitting();
 
-		// Send event. Best-effort: the analytics event must never block the
-		// actual deactivation redirect, so deactivatePlugin() runs whether or
-		// not the request succeeds.
-		return await sendSurveyEvent( skipped )
-			.catch( ( error ) => {
-				console.error( 'Error: Failed to send deactivation survey event.', error );
-			} )
-			.then( () => {
-				deactivatePlugin();
-			} );
+		// Fire-and-forget: the analytics event is best-effort and must never
+		// delay or block the actual deactivation redirect, whether it
+		// succeeds, fails, or is still in flight.
+		sendSurveyEvent( skipped ).catch( ( error ) => {
+			console.error( 'Error: Failed to send deactivation survey event.', error );
+		} );
+
+		deactivatePlugin();
 	};
 
 	/**

--- a/static/js/deactivation-survey.js
+++ b/static/js/deactivation-survey.js
@@ -230,10 +230,16 @@
 	const submitSurvey = async ( skipped = false ) => {
 		isSubmitting();
 
-		// Send event
-		return await sendSurveyEvent( skipped ).then( () => {
-			deactivatePlugin();
-		} );
+		// Send event. Best-effort: the analytics event must never block the
+		// actual deactivation redirect, so deactivatePlugin() runs whether or
+		// not the request succeeds.
+		return await sendSurveyEvent( skipped )
+			.catch( ( error ) => {
+				console.error( 'Error: Failed to send deactivation survey event.', error );
+			} )
+			.then( () => {
+				deactivatePlugin();
+			} );
 	};
 
 	/**


### PR DESCRIPTION
## Proposed changes

`submitSurvey()` in `static/js/deactivation-survey.js` chains:

```js
return await sendSurveyEvent( skipped ).then( () => {
  deactivatePlugin();
} );
```

There's no `.catch()` anywhere in the `sendSurveyEvent` → `sendEvent` → `fetch()` chain. If that request ever rejects, `deactivatePlugin()` (which does `window.location.href = deactivateLink`) silently never runs — the modal proceeds to its "goodbye" step but the plugin is never actually deactivated.

The analytics event here is best-effort and should never block the actual deactivation action. This adds a `.catch()` that logs the failure and still proceeds to `deactivatePlugin()`.

We ran into this while chasing an e2e failure in `wp-plugin-bluehost`'s Playwright suite where `deactivation-survey.spec.mjs`'s "Skip action works and deactivates plugin" / "Modal Submit survey action works" tests failed to find the plugin deactivated afterward (see [newfold-labs/wp-plugin-bluehost#1380](https://github.com/newfold-labs/wp-plugin-bluehost/pull/1380)). We couldn't confirm this is the exact trigger there (couldn't pull the browser trace to see if the event request rejected), but it's a real gap regardless of whether it's the full explanation.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_017ZMaQfcF8kbvMfsc3qmm5r)_