### PR TITLE
Fix flaky deactivation survey tests

### DIFF
--- a/tests/playwright/helpers/index.mjs
+++ b/tests/playwright/helpers/index.mjs
@@ -1,6 +1,6 @@
 /**
  * Deactivation Module Test Helpers for Playwright
- * 
+ *
  * Utilities for testing the Deactivation module functionality.
  * Includes plugin activation/deactivation helpers and survey interactions.
  */
@@ -25,136 +25,187 @@ let { auth, wordpress, newfold, a11y, utils } = pluginHelpers;
 // destructure wpCli from wordpress
 const { wpCli } = wordpress;
 const { fancyLog } = utils;
+const clearInstallerQueues = newfold.clearInstallerQueues;
 
 /**
  * Get deactivation link for plugin
- * 
+ *
  * @param {import('@playwright/test').Page} page - Playwright page object
  * @param {string} pluginId - Plugin ID
  * @returns {import('@playwright/test').Locator} Deactivation link locator
  */
 const getDeactivationLink = (page, pluginId) => {
-    return page.locator(`.deactivate a[id*="${pluginId}"]`);
-  }
-  
-  /**
-   * Get activation link for plugin
-   * 
-   * @param {import('@playwright/test').Page} page - Playwright page object
-   * @param {string} pluginId - Plugin ID
-   * @returns {import('@playwright/test').Locator} Activation link locator
-   */
-  const getActivationLink = (page, pluginId) => {
-    return page.locator(`.activate a[id*="${pluginId}"]`);
-  }
-  
-  /**
-   * Trigger deactivation modal
-   * 
-   * @param {import('@playwright/test').Page} page - Playwright page object
-   * @param {string} pluginId - Plugin ID
-   */
-  const triggerDeactivationModal = async (page, pluginId) => {
-    fancyLog('Clicking Deactivate link to Open Deactivation Modal');
-    const deactivateLink = getDeactivationLink(page, pluginId);
-    await deactivateLink.click();
-  }
-  
-  /**
-   * Verify plugin is deactivated via wp-admin interface
-   * 
-   * @param {import('@playwright/test').Page} page - Playwright page object
-   * @param {string} pluginId - Plugin ID
-   */
-  const verifyPluginDeactivated = async (page, pluginId) => {
-    fancyLog('Verifying Plugin is Not Active');
-    const deactivateLink = getDeactivationLink(page, pluginId);
-    await expect(deactivateLink).not.toBeVisible(); // Should not be visible if deactivated
-    
-    const activateLink = getActivationLink(page, pluginId);
-    await expect(activateLink).toBeVisible(); // Should be visible if deactivated
-  }
-  
-  /**
-   * Verify plugin is active via wp-admin interface
-   * 
-   * @param {import('@playwright/test').Page} page - Playwright page object
-   * @param {string} pluginId - Plugin ID
-   */
-  const verifyPluginActive = async (page, pluginId) => {
-    fancyLog('Verifying Plugin is Active');
-    const activateLink = getActivationLink(page, pluginId);
-    await expect(activateLink).not.toBeVisible();
-    
-    const deactivateLink = getDeactivationLink(page, pluginId);
-    await expect(deactivateLink).toBeVisible();
-  }
-  
-  /**
-   * Activate plugin via wp-admin interface
-   * 
-   * @param {import('@playwright/test').Page} page - Playwright page object
-   * @param {string} pluginId - Plugin ID
-   */
-  const activatePlugin = async (page, pluginId) => {
-    fancyLog('Clicking Activate Link to Activate Plugin');
-    const activateLink = getActivationLink(page, pluginId);
-    await activateLink.click();
-    
-    // Wait for activation to complete
-    await page.waitForTimeout(1000);
+  return page.locator(`.deactivate a[id*="${pluginId}"]`);
+};
+
+/**
+ * Get activation link for plugin
+ *
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @param {string} pluginId - Plugin ID
+ * @returns {import('@playwright/test').Locator} Activation link locator
+ */
+const getActivationLink = (page, pluginId) => {
+  return page.locator(`.activate a[id*="${pluginId}"]`);
+};
+
+/**
+ * Trigger deactivation modal
+ *
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @param {string} pluginId - Plugin ID
+ */
+const triggerDeactivationModal = async (page, pluginId) => {
+  fancyLog('Clicking Deactivate link to Open Deactivation Modal');
+  const deactivateLink = getDeactivationLink(page, pluginId);
+  await deactivateLink.click();
+};
+
+/**
+ * Verify plugin is deactivated via wp-admin interface
+ *
+ * Assert the Activate link is present first. Checking only that Deactivate is
+ * missing also matches a blank/loading plugins page mid-navigation after Skip
+ * or Submit redirects via window.location.href — the intermittent CI failure
+ * mode for this suite.
+ *
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @param {string} pluginId - Plugin ID
+ */
+const verifyPluginDeactivated = async (page, pluginId) => {
+  fancyLog('Verifying Plugin is Not Active');
+  const activateLink = getActivationLink(page, pluginId);
+  // Deactivation is a full plugins.php round-trip (including flush_rewrite_rules
+  // in on_deactivate). Allow the same budget as a test-level action, not the
+  // default 5s expect timeout.
+  await expect(activateLink).toBeVisible({ timeout: 30000 });
+
+  const deactivateLink = getDeactivationLink(page, pluginId);
+  await expect(deactivateLink).not.toBeVisible();
+};
+
+/**
+ * Verify plugin is active via wp-admin interface
+ *
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @param {string} pluginId - Plugin ID
+ */
+const verifyPluginActive = async (page, pluginId) => {
+  fancyLog('Verifying Plugin is Active');
+  const deactivateLink = getDeactivationLink(page, pluginId);
+  await expect(deactivateLink).toBeVisible({ timeout: 30000 });
+
+  const activateLink = getActivationLink(page, pluginId);
+  await expect(activateLink).not.toBeVisible();
+};
+
+/**
+ * Activate plugin via wp-admin interface
+ *
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @param {string} pluginId - Plugin ID
+ */
+const activatePlugin = async (page, pluginId) => {
+  fancyLog('Clicking Activate Link to Activate Plugin');
+  const activateLink = getActivationLink(page, pluginId);
+  // Do not waitForURL(/plugins\.php/) here — the page is already on plugins.php,
+  // so that waiter resolves immediately and races the activate redirect.
+  await activateLink.click();
+  await verifyPluginActive(page, pluginId);
+};
+
+/**
+ * Resolve the installed plugin slug for a brand pluginId.
+ *
+ * Local wp-env mounts the checkout as `bluehost-wordpress-plugin`. CI rsyncs
+ * into `$DIST/wp-plugin-bluehost` (github.repository basename), so a hardcoded
+ * path silently fails `wp plugin activate` there. Once a prior test leaves the
+ * plugin inactive, the next beforeEach cannot recover — which is how Skip
+ * flakes cascade into Submit.
+ *
+ * @param {string} pluginId - Plugin ID (e.g. 'bluehost')
+ * @returns {Promise<string>} WP-CLI plugin slug (directory name)
+ */
+const resolvePluginSlug = async (pluginId) => {
+  const raw = await wpCli('plugin list --format=json --skip-plugins --skip-themes', {
+    failOnNonZeroExit: true,
+  });
+  const plugins = JSON.parse(typeof raw === 'string' ? raw : '[]');
+  const preferred = [
+    `wp-plugin-${pluginId}`,
+    `${pluginId}-wordpress-plugin`,
+  ];
+  const match =
+    preferred
+      .map((name) => plugins.find((plugin) => plugin.name === name))
+      .find(Boolean) ||
+    plugins.find(
+      (plugin) =>
+        plugin.name.includes(pluginId) ||
+        plugin.name.includes(`wp-plugin-${pluginId}`)
+    );
+
+  if (!match) {
+    throw new Error(
+      `Could not resolve plugin slug for "${pluginId}". Installed: ${plugins
+        .map((plugin) => plugin.name)
+        .join(', ')}`
+    );
   }
 
-  /**
-   * Activate plugin via CLI
-   * 
-   * @param {import('@playwright/test').Page} page - Playwright page object
-   * @param {string} pluginId - Plugin ID
-   */
-  const activatePluginViaCLI = async (page, pluginId) => {
-    fancyLog('Activating Plugin via CLI');
-    const pluginSlug = getPluginSlug(pluginId);
-    await wpCli(`plugin activate ${pluginSlug}`);
-  }
+  return match.name;
+};
 
-  /**
-   * Get plugin slug from plugin ID
-   * 
-   * @param {string} pluginId - Plugin ID
-   * @returns {string} Plugin slug
-   */
-  const getPluginSlug = (pluginId) => {
-    if (pluginId === 'bluehost' ) {
-        return 'bluehost-wordpress-plugin/bluehost-wordpress-plugin.php'; // local
-        // return 'wp-plugin-bluehost/wp-plugin-bluehost.php'; // runner
-    } else if (pluginId === 'hostgator') {
-        return 'wp-plugin-hostgator/wp-plugin-hostgator.php';
-    } else if (pluginId === 'crazy-domains') {
-        return 'wp-plugin-crazy-domains/wp-plugin-crazy-domains.php';
-    } else if (pluginId === 'web') {
-        return 'wp-plugin-web/wp-plugin-web.php';
-    } else if (pluginId === 'mojo') {
-        return 'wp-plugin-mojo/wp-plugin-mojo.php';
-    } else {
-        throw new Error(`Invalid plugin ID: ${pluginId}`);
-    }
-  }
+/**
+ * Activate plugin via CLI
+ *
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @param {string} pluginId - Plugin ID
+ */
+const activatePluginViaCLI = async (page, pluginId) => {
+  fancyLog('Activating Plugin via CLI');
+  const pluginSlug = await resolvePluginSlug(pluginId);
+  // --skip-plugins: change active_plugins without bootstrapping a stack that may
+  // currently be fataling (e.g. after a partial installer run).
+  await wpCli(`plugin activate ${pluginSlug} --skip-plugins --skip-themes`, {
+    failOnNonZeroExit: true,
+  });
+};
 
+/**
+ * Run a Skip/Submit action and wait until deactivation has finished.
+ *
+ * Skip/Submit set window.location.href to the deactivate URL. Waiting for the
+ * modal to disappear is not enough — that passes as soon as the old document is
+ * torn down. waitForURL(/plugins.php/) is also unsafe here because the page is
+ * already on plugins.php, so the waiter can resolve before the redirect runs.
+ * Wait for the Activate link instead (the post-deactivation plugins list).
+ *
+ * @param {import('@playwright/test').Page} page - Playwright page object
+ * @param {string} pluginId - Plugin ID
+ * @param {() => Promise<void>} action - Click that starts deactivation
+ */
+const waitForDeactivationNavigation = async (page, pluginId, action) => {
+  await action();
+  await verifyPluginDeactivated(page, pluginId);
+};
 
 export {
-    // Plugin helpers (re-exported for convenience)
-    auth,
-    wordpress,
-    newfold,
-    a11y,
-    utils,
-    // module specific helpers
-    getDeactivationLink,
-    getActivationLink,
-    triggerDeactivationModal,
-    verifyPluginDeactivated,
-    verifyPluginActive,
-    activatePlugin,
-    activatePluginViaCLI,
-    getPluginSlug,
+  // Plugin helpers (re-exported for convenience)
+  auth,
+  wordpress,
+  newfold,
+  a11y,
+  utils,
+  // module specific helpers
+  getDeactivationLink,
+  getActivationLink,
+  triggerDeactivationModal,
+  verifyPluginDeactivated,
+  verifyPluginActive,
+  activatePlugin,
+  activatePluginViaCLI,
+  resolvePluginSlug,
+  waitForDeactivationNavigation,
+  clearInstallerQueues,
 };

--- a/tests/playwright/specs/deactivation-survey.spec.mjs
+++ b/tests/playwright/specs/deactivation-survey.spec.mjs
@@ -2,10 +2,10 @@ import { test, expect } from '@playwright/test';
 import {
   auth,
   triggerDeactivationModal,
-  verifyPluginDeactivated,
   verifyPluginActive,
-  activatePlugin,
-  activatePluginViaCLI
+  activatePluginViaCLI,
+  waitForDeactivationNavigation,
+  clearInstallerQueues,
 } from '../helpers';
 
 // Use environment variable to resolve plugin helpers
@@ -15,19 +15,30 @@ test.describe('Plugin Deactivation Survey', () => {
   let surveyRuntimeData;
 
   test.beforeEach(async ({ page }) => {
+    // Drop any installer work left by earlier projects before we activate.
+    await clearInstallerQueues();
+
     // Login to WordPress
     await auth.loginToWordPress(page);
     await activatePluginViaCLI(page, pluginId);
-    
+    // Activating can re-seed the installer queue — clear again so a mid-suite
+    // install cannot race the plugins screen during Skip/Submit.
+    await clearInstallerQueues();
+
     // Navigate to plugins page
     await page.goto('/wp-admin/plugins.php');
     await page.waitForLoadState('load');
-    
+    // Own the active-plugin precondition here. CLI activate used to hardcode the
+    // local directory name and fail silently on CI's wp-plugin-* install path, so
+    // a prior test that left the plugin inactive cascaded into "Deactivate link
+    // not found" on the next test.
+    await verifyPluginActive(page, pluginId);
+
     // Get survey runtime data
     surveyRuntimeData = await page.evaluate(() => {
       return window.NewfoldRuntime?.data || {};
     });
-    
+
     // Setup API intercepts
     await page.route('**/newfold-data/v1/events**', async route => {
       await route.fulfill({
@@ -158,45 +169,53 @@ test.describe('Plugin Deactivation Survey', () => {
   });
 
   test('Skip action works and deactivates plugin', async ({ page }) => {
+    test.setTimeout(60000);
     // Define selectors
     const modalContainer = '.nfd-deactivation-survey__container';
     const step1ContinueButton = 'button[nfd-deactivation-survey-next]';
     const step2SkipButton = 'button[nfd-deactivation-survey-skip]';
-    
+
     // Skip action works
     await triggerDeactivationModal(page, pluginId);
     await page.locator(step1ContinueButton).click();
-    
+
     // Set up request interception BEFORE triggering the action
     const requestPromise = page.waitForRequest(request =>
       request.url().includes('/newfold-data/v1/events') && request.method() === 'POST'
     );
-    
-    // Now click the skip button
-    await page.locator(step2SkipButton).click();
-    
-    // Wait for and validate the request payload
-    const request = await requestPromise;
+
+    // Skip redirects via window.location.href — wait for the plugins-page reload,
+    // not a fixed timeout after "modal gone" (that passes on document teardown).
+    const [request] = await Promise.all([
+      requestPromise,
+      waitForDeactivationNavigation(page, pluginId, async () => {
+        await page.locator(step2SkipButton).click();
+      }),
+    ]);
+
+    // Validate the request payload
     const requestBody = request.postDataJSON();
     expect(requestBody.data.survey_input).toBe('(Skipped)');
-    
-    // Verify modal closed and plugin deactivated
+
+    // waitForDeactivationNavigation already asserted the Activate link; confirm
+    // the survey UI is gone on the reloaded plugins page.
     await expect(page.locator(modalContainer)).not.toBeVisible();
-    await page.waitForTimeout(1000); // Wait for deactivation to complete
-    await verifyPluginDeactivated(page, pluginId);
-    
-    // Activate plugin and verify
-    await activatePlugin(page, pluginId);
-    await verifyPluginActive(page, pluginId);
+
+    // Reactivate via CLI (not the plugins-row UI). UI activation re-runs plugin
+    // bootstrap, which re-seeds the installer queue; a fast cron install of a
+    // companion plugin has been observed to fatal this screen before the next test.
+    await activatePluginViaCLI(page, pluginId);
+    await clearInstallerQueues();
   });
 
   test('Modal Submit survey action works', async ({ page }) => {
+    test.setTimeout(60000);
     // Define selectors
     const modalContainer = '.nfd-deactivation-survey__container';
     const step1ContinueButton = 'button[nfd-deactivation-survey-next]';
     const surveyTextarea = '#nfd-deactivation-survey__input';
     const submitButton = 'input[nfd-deactivation-survey-submit]';
-    
+
     // Open modal and go to step 2
     await triggerDeactivationModal(page, pluginId);
     await page.locator(step1ContinueButton).click();
@@ -204,27 +223,26 @@ test.describe('Plugin Deactivation Survey', () => {
     // Enter reason and submit
     const ugcReason = 'automated testing';
     await page.locator(surveyTextarea).fill(ugcReason);
-    
+
     // Set up request interception BEFORE triggering the action
     const requestPromise = page.waitForRequest(request =>
       request.url().includes('/newfold-data/v1/events') && request.method() === 'POST'
     );
-    
-    // Now click the submit button
-    await page.locator(submitButton).click();
-    
-    // Wait for and validate the request payload
-    const request = await requestPromise;
+
+    const [request] = await Promise.all([
+      requestPromise,
+      waitForDeactivationNavigation(page, pluginId, async () => {
+        await page.locator(submitButton).click();
+      }),
+    ]);
+
+    // Validate the request payload
     const requestBody = request.postDataJSON();
     expect(requestBody.data.survey_input).toBe(ugcReason);
-    
-    // Verify modal closed and plugin deactivated
+
     await expect(page.locator(modalContainer)).not.toBeVisible();
-    await page.waitForTimeout(1000); // Wait for deactivation to complete
-    await verifyPluginDeactivated(page, pluginId);
-    
-    // Activate plugin and verify
-    await activatePlugin(page, pluginId);
-    await verifyPluginActive(page, pluginId);
+
+    await activatePluginViaCLI(page, pluginId);
+    await clearInstallerQueues();
   });
 });


### PR DESCRIPTION
## Summary

The `Skip action works and deactivates plugin` and `Modal Submit survey action works` specs failed intermittently in CI (roughly 1 in 20 runs) with `element(s) not found` on the Activate link, then a cascading 30s timeout on the Deactivate link in the following test.

Two independent causes, both fixed here.

### 1. The specs never waited for the deactivation reload

Skip/Submit deactivate by setting `window.location.href` to the deactivate URL. The specs treated "modal gone" plus a fixed `waitForTimeout(1000)` as proof the reload had finished, then asserted the Deactivate link was **absent** — an assertion that also passes on a blank page mid-navigation. The only real check was the Activate link assertion immediately after, which is what flaked when CI was slow.

Now the specs wait for the Activate link (the post-deactivation plugins list) as the completion signal, and `verifyPluginDeactivated` asserts presence before absence so a half-loaded page can no longer look like success.

### 2. CLI activation silently failed in CI, causing the cascade

`activatePluginViaCLI` used a hardcoded slug:

```js
return 'bluehost-wordpress-plugin/bluehost-wordpress-plugin.php'; // local
// return 'wp-plugin-bluehost/wp-plugin-bluehost.php'; // runner
```

CI rsyncs the plugin into `$DIST/wp-plugin-bluehost` (the `github.repository` basename), so the activate call failed there — and the result was discarded. While the plugin happened to be active this went unnoticed. Once Skip left it inactive, `beforeEach` could not recover, and the next test had no Deactivate link to click.

`resolvePluginSlug()` now resolves the real directory name from `wp plugin list`, works for both layouts, and throws with the installed plugin list when it cannot match. The commented-out runner line and the now-unused `getPluginSlug()` are removed.

### Supporting hardening

- `beforeEach` asserts the active-plugin precondition instead of inheriting it, so a setup failure reports itself rather than surfacing as a missing-link error later.
- Installer queues are cleared around activation. Locally this suite was installing `jetpack-boost` mid-run, which fataled the plugins screen (`class ObjectCache not found`) and broke every subsequent assertion.
- Skip/Submit reactivate via CLI rather than the plugins-row UI, since UI activation re-runs plugin bootstrap and re-seeds that queue.
- WP-CLI calls use `--skip-plugins --skip-themes`; they only touch `active_plugins`, and this keeps cleanup working when the plugin stack is fataling — exactly when it matters most.

> [!NOTE]
> Depends on `clearInstallerQueues()` in the host plugin's Playwright helpers (already on `wp-plugin-bluehost` `develop`). This module's tests run against the host plugin's helper directory, so that needs to land first.

The helpers file also picks up whitespace/indentation normalization; it was previously indented inconsistently. Reviewing with whitespace hidden makes the functional changes much easier to read.

## Test plan

- [x] Reproduced the original failure locally by delaying the deactivate navigation and confirming the fixed-timeout assertions passed on a torn-down page
- [x] All 4 deactivation survey specs pass locally with `--retries=0` (~55s)
- [x] Confirmed CLI activation resolves `bluehost-wordpress-plugin` locally; `wp-plugin-bluehost` is matched by the same preferred-name lookup
- [ ] CI matrix green across the PHP/WP combinations
- [ ] Re-run the suite a few times to confirm the intermittent failure is gone

Made with [Cursor](https://cursor.com)